### PR TITLE
Theme-Color

### DIFF
--- a/SkinLiberty.php
+++ b/SkinLiberty.php
@@ -10,6 +10,10 @@ class SkinLiberty extends SkinTemplate {
         $out->addMeta( 'viewport', 'width=device-width, initial-scale=1, maximum-scale=1' );
         $out->addMeta( 'description', 'librewiki' );
         $out->addMeta( 'keywords', 'wiki,librewiki,리브레위키,리브레 위키,' . $this->getSkin()->getTitle() );
+//	크롬, 파이어폭스 OS, 오페라
+	$out->addMeta('theme-color', '#4188F1');
+//	윈도우 폰
+	$out->addMeta('msapplication-navbutton-color', '#4188F1'); 
         $out->addModuleScripts( array(
             'skins.liberty.bootstrap'
         ) );


### PR DESCRIPTION
모바일 크롬등의 브라우저에서 메인 컬러를 인식하게 해줍니다.
모바일 크롬에서 테스트 했을때 주소창의 색상이 변경되었습니다.
색상은 CSS의 색상을 사용했습니다.
해당 내용은 여기에서 보실 수 있습니다. (https://developers.google.com/web/fundamentals/design-and-ui/browser-customization/theme-color)
모바일 크롬에서의 화면은 여기에서 보실 수 있습니다.(https://imgur.com/gallery/D7g7rSk)
