### PR TITLE
Coding style tweaks

### DIFF
--- a/LibertyHooks.php
+++ b/LibertyHooks.php
@@ -1,5 +1,5 @@
 <?php //phpcs:ignore
-class LibertyHooks extends Hooks{
+class LibertyHooks extends Hooks {
 	/**
 	 * @since 1.17.0
 	 * @param OutputPage $out
@@ -13,15 +13,17 @@ class LibertyHooks extends Hooks{
 	}
 
 	/**
-	 * Preference
+	 * Set up user preferences specific to the Liberty skin.
+	 *
 	 * @param User $user user
 	 * @param Preferences &$preferences preferences
 	 */
 	public static function onGetPreferences( $user, &$preferences ) {
 		global $wgLibertyAdSetting, $wgLibertyAdGroup;
+
 		$service = MediaWiki\MediaWikiServices::getInstance();
-		$usergroupemanager = $service->getUserGroupManager();
-		$userGroups = $usergroupemanager->getUserGroups( $user );
+		$userGroupManager = $service->getUserGroupManager();
+		$userGroups = $userGroupManager->getUserGroups( $user );
 		$permissionManager = $service->getPermissionManager();
 
 		$preferences['liberty-layout-width'] = [
@@ -59,10 +61,14 @@ class LibertyHooks extends Hooks{
 			'section' => 'liberty/layout',
 		];
 
-		if ( isset( $wgLibertyAdSetting['client'] ) && $wgLibertyAdSetting['client'] &&
-		isset( $wgLibertyAdGroup ) && $wgLibertyAdGroup == 'differ' ) {
-			if ( isset( $wgLibertyAdSetting['belowarticle'] ) && $wgLibertyAdSetting['belowarticle']
-			&& $permissionManager->userHasRight( $user, 'blockads-belowarticle' ) ) {
+		if (
+			isset( $wgLibertyAdSetting['client'] ) && $wgLibertyAdSetting['client'] &&
+			isset( $wgLibertyAdGroup ) && $wgLibertyAdGroup == 'differ'
+		) {
+			if (
+				isset( $wgLibertyAdSetting['belowarticle'] ) && $wgLibertyAdSetting['belowarticle'] &&
+				$permissionManager->userHasRight( $user, 'blockads-belowarticle' )
+			) {
 				$preferences['liberty-ads-morearticle'] = [
 					'type' => 'toggle',
 					'label-message' => 'liberty-pref-ads-belowarticle',
@@ -70,8 +76,10 @@ class LibertyHooks extends Hooks{
 				];
 			}
 
-			if ( isset( $wgLibertyAdSetting['header'] ) && $wgLibertyAdSetting['header'] &&
-			$permissionManager->userHasRight( $user, 'blockads-header' ) ) {
+			if (
+				isset( $wgLibertyAdSetting['header'] ) && $wgLibertyAdSetting['header'] &&
+				$permissionManager->userHasRight( $user, 'blockads-header' )
+			) {
 				$preferences['liberty-ads-header'] = [
 					'type' => 'toggle',
 					'label-message' => 'liberty-pref-ads-header',
@@ -79,8 +87,10 @@ class LibertyHooks extends Hooks{
 				];
 			}
 
-			if ( isset( $wgLibertyAdSetting['right'] ) && $wgLibertyAdSetting['right'] &&
-			$permissionManager->userHasRight( $user, 'blockads-right' ) ) {
+			if (
+				isset( $wgLibertyAdSetting['right'] ) && $wgLibertyAdSetting['right'] &&
+				$permissionManager->userHasRight( $user, 'blockads-right' )
+			) {
 				$preferences['liberty-ads-rightads'] = [
 					'type' => 'toggle',
 					'label-message' => 'liberty-pref-ads-right',
@@ -88,8 +98,10 @@ class LibertyHooks extends Hooks{
 				];
 			}
 
-			if ( isset( $wgLibertyAdSetting['bottom'] ) && $wgLibertyAdSetting['bottom'] &&
-			$permissionManager->userHasRight( $user, 'blockads-bottom' ) ) {
+			if (
+				isset( $wgLibertyAdSetting['bottom'] ) && $wgLibertyAdSetting['bottom'] &&
+				$permissionManager->userHasRight( $user, 'blockads-bottom' )
+			) {
 				$preferences['liberty-ads-bottom'] = [
 					'type' => 'toggle',
 					'label-message' => 'liberty-pref-ads-bottom',

--- a/LibertyTemplate.php
+++ b/LibertyTemplate.php
@@ -32,7 +32,7 @@ class LibertyTemplate extends BaseTemplate {
 							<div class="live-recent-wrapper">
 								<?php $this->liveRecent(); ?>
 							</div>
-							<?php if ( isset( $wgLibertyAdSetting[ 'right' ] ) && $wgLibertyAdSetting[ 'right' ] ) {
+							<?php if ( isset( $wgLibertyAdSetting['right'] ) && $wgLibertyAdSetting['right'] ) {
 								$this->buildAd( 'right' );
 							} ?>
 						</div>
@@ -77,7 +77,7 @@ class LibertyTemplate extends BaseTemplate {
 						</article>
 						<?php
 						if ( isset( $wgLibertyAdSetting['belowarticle'] ) && $wgLibertyAdSetting['belowarticle'] ) {
-								$this->buildAd( 'belowarticle' );
+							$this->buildAd( 'belowarticle' );
 						}
 						?>
 						</div>
@@ -92,8 +92,10 @@ class LibertyTemplate extends BaseTemplate {
 						<?php if ( isset( $wgLibertyAdSetting['bottom'] ) && $wgLibertyAdSetting['bottom'] ) {
 							$this->buildAd( 'bottom' );
 						}
-						if ( isset( $wgLibertyMobileReplaceAd ) && $wgLibertyMobileReplaceAd &&
-						isset( $wgLibertyAdSetting[ 'right' ] ) && $wgLibertyAdSetting[ 'right' ] ) { ?>
+						if (
+							isset( $wgLibertyMobileReplaceAd ) && $wgLibertyMobileReplaceAd &&
+							isset( $wgLibertyAdSetting['right'] ) && $wgLibertyAdSetting['right']
+						) { ?>
 							<div class="mobile-ads"></div>
 						<?php } ?>
 							<?php $this->footer(); ?>
@@ -110,7 +112,7 @@ class LibertyTemplate extends BaseTemplate {
 		// Only load AdSense JS is ads are enabled in site configuration
 		if ( isset( $wgLibertyAdSetting['client'] ) && $wgLibertyAdSetting['client'] ) {
 			// @codingStandardsIgnoreLine
-			echo( '<script async defer src="//pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>' );
+			echo '<script async defer src="//pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>';
 		}
 		?>
 		<?php $this->loginModal(); ?>
@@ -136,7 +138,7 @@ class LibertyTemplate extends BaseTemplate {
 					<?php echo $linkRenderer->makeKnownLink(
 						new TitleValue( NS_SPECIAL, 'Recentchanges' ),
 						// @codingStandardsIgnoreStart
-						new HtmlArmor('<span class="fas fa-sync"></span><span class="hide-title">' . $skin->msg( 'recentchanges' )->plain() . '</span>'),
+						new HtmlArmor( '<span class="fas fa-sync"></span><span class="hide-title">' . $skin->msg( 'recentchanges' )->plain() . '</span>' ),
 						// @codingStandardsIgnoreEnd )
 						[
 							'class' => 'nav-link',
@@ -148,7 +150,7 @@ class LibertyTemplate extends BaseTemplate {
 					<?php echo $linkRenderer->makeKnownLink(
 						new TitleValue( NS_SPECIAL, 'Randompage' ),
 						// @codingStandardsIgnoreStart
-						new HtmlArmor('<span class="fa fa-random"></span><span class="hide-title">' . $skin->msg('randompage')->plain() . '</span>'),
+						new HtmlArmor( '<span class="fa fa-random"></span><span class="hide-title">' . $skin->msg( 'randompage' )->plain() . '</span>' ),
 						// @codingStandardsIgnoreEnd
 						[
 							'class' => 'nav-link',
@@ -356,23 +358,23 @@ class LibertyTemplate extends BaseTemplate {
 						<button type="button" class="close" data-dismiss="modal" aria-label="Close">
 							<span aria-hidden="true">&times;</span>
 						</button>
-						<h4 class="modal-title"><?php echo $skin->msg('liberty-login')->plain() ?></h4>
+						<h4 class="modal-title"><?php echo $skin->msg( 'liberty-login' )->plain() ?></h4>
 					</div>
 					<div class="modal-body">
 						<div id="modal-login-alert" class="alert alert-hidden alert-danger" role="alert">
 						</div>
 						<form id="modal-loginform" name="userlogin" class="modal-loginform" method="post">
-							<input class="loginText form-control" id="wpName1" tabindex="1" placeholder="<?php echo $skin->msg('userlogin-yourname-ph')->plain() ?>" value="" name="lgname">
-							<label for="inputPassword" class="sr-only"><?php echo $skin->msg('userlogin-yourpassword')->plain() ?></label>
-							<input class="loginPassword form-control" id="wpPassword1" tabindex="2" placeholder="<?php echo $skin->msg('userlogin-yourpassword-ph')->plain() ?>" type="password" name="lgpassword">
+							<input class="loginText form-control" id="wpName1" tabindex="1" placeholder="<?php echo $skin->msg( 'userlogin-yourname-ph' )->plain() ?>" value="" name="lgname">
+							<label for="inputPassword" class="sr-only"><?php echo $skin->msg( 'userlogin-yourpassword' )->plain() ?></label>
+							<input class="loginPassword form-control" id="wpPassword1" tabindex="2" placeholder="<?php echo $skin->msg( 'userlogin-yourpassword-ph' )->plain() ?>" type="password" name="lgpassword">
 							<div class="modal-checkbox">
 								<input name="lgremember" type="checkbox" value="1" id="lgremember" tabindex="3">
-								<label for="lgremember"><?php echo $skin->msg('liberty-remember')->plain() ?></label>
+								<label for="lgremember"><?php echo $skin->msg( 'liberty-remember' )->plain() ?></label>
 							</div>
-							<input class="btn btn-success btn-block" type="submit" value="<?php echo $skin->msg('liberty-login-btn')->plain() ?>" tabindex="4">
+							<input class="btn btn-success btn-block" type="submit" value="<?php echo $skin->msg( 'liberty-login-btn' )->plain() ?>" tabindex="4">
 							<?php echo $linkRenderer->makeKnownLink(
-								SpecialPage::getTitleFor('Userlogin'),
-								$skin->msg('userlogin-joinproject'),
+								SpecialPage::getTitleFor( 'Userlogin' ),
+								$skin->msg( 'userlogin-joinproject' ),
 								[
 									'class' => 'btn btn-primary btn-block',
 									'tabindex' => 5,
@@ -384,21 +386,21 @@ class LibertyTemplate extends BaseTemplate {
 								]
 							); ?>
 							<?php echo $linkRenderer->makeKnownLink(
-								SpecialPage::getTitleFor('PasswordReset'),
-								$skin->msg('liberty-forgot-pw')->plain()
+								SpecialPage::getTitleFor( 'PasswordReset' ),
+								$skin->msg( 'liberty-forgot-pw' )->plain()
 							); ?>
 							<br>
 							<?php echo $linkRenderer->makeKnownLink(
-								SpecialPage::getTitleFor('Userlogin'),
-								$skin->msg('liberty-login-alter')->plain()
+								SpecialPage::getTitleFor( 'Userlogin' ),
+								$skin->msg( 'liberty-login-alter' )->plain()
 							); ?>
 							<input type="hidden" name="action" value="login" />
 							<input type="hidden" name="format" value="json" />
 						</form>
 					</div>
 					<div class="modal-footer">
-						<button type="button" class="btn btn-secondary" data-dismiss="modal"><?php echo $skin->msg('liberty-btn-close')->plain(); ?></button>
-						<button type="button" class="btn btn-primary"><?php echo $skin->msg('liberty-btn-save-changes')->plain(); ?></button>
+						<button type="button" class="btn btn-secondary" data-dismiss="modal"><?php echo $skin->msg( 'liberty-btn-close' )->plain(); ?></button>
+						<button type="button" class="btn btn-primary"><?php echo $skin->msg( 'liberty-btn-save-changes' )->plain(); ?></button>
 					</div>
 				</div>
 			</div>
@@ -416,15 +418,17 @@ class LibertyTemplate extends BaseTemplate {
 			$wgLibertyMaxRecent,
 			$wgLibertyLiveRCArticleNamespaces,
 			$wgLibertyLiveRCTalkNamespaces;
+
 		// Don't bother outputting this if the live RC feature is disabled in
 		// site configuration
 		if ( !$wgLibertyEnableLiveRC ) {
 			return;
 		}
+
 		$skin = $this->getSkin();
 		$linkRenderer = MediaWikiServices::getInstance()->getLinkRenderer();
-		$articleNS = implode( "|", $wgLibertyLiveRCArticleNamespaces );
-		$talkNS = implode( "|", $wgLibertyLiveRCTalkNamespaces );
+		$articleNS = implode( '|', $wgLibertyLiveRCArticleNamespaces );
+		$talkNS = implode( '|', $wgLibertyLiveRCTalkNamespaces );
 	?>
 		<div class="live-recent" data-article-ns="<?php echo $articleNS ?>" 
 			data-talk-ns="<?php echo $talkNS ?>">
@@ -734,7 +738,8 @@ class LibertyTemplate extends BaseTemplate {
 			if ( !$content ) {
 				break;
 			}
-			if ( ( $content['right'] && !in_array( $content['right'], $userRights ) ) ||
+			if (
+				( $content['right'] && !in_array( $content['right'], $userRights ) ) ||
 				( $content['group'] && !in_array( $content['group'], $userGroup ) )
 			) {
 				continue;
@@ -782,7 +787,8 @@ class LibertyTemplate extends BaseTemplate {
 				] );
 
 				foreach ( $content['children'] as $child ) {
-					if ( ( $child['right'] && !in_array( $child['right'], $userRights ) ) ||
+					if (
+						( $child['right'] && !in_array( $child['right'], $userRights ) ) ||
 						( $child['group'] && !in_array( $child['group'], $userGroup ) )
 					) {
 						continue;
@@ -823,7 +829,8 @@ class LibertyTemplate extends BaseTemplate {
 						] );
 
 						foreach ( $child['children'] as $sub ) {
-							if ( ( $sub['right'] && !in_array( $sub['right'], $userRights ) ) ||
+							if (
+								( $sub['right'] && !in_array( $sub['right'], $userRights ) ) ||
 								( $sub['group'] && !in_array( $sub['group'], $userGroup ) )
 							) {
 								continue;
@@ -945,7 +952,7 @@ class LibertyTemplate extends BaseTemplate {
 						$text = $textObj->text();
 					}
 				} else {
-					$text = "";
+					$text = '';
 				}
 
 				// If icon and text both empty
@@ -1044,7 +1051,7 @@ class LibertyTemplate extends BaseTemplate {
 						$text = $textObj->text();
 					}
 				} else {
-					$text = "";
+					$text = '';
 				}
 
 				// If icon and text both empty

--- a/SkinLiberty.php
+++ b/SkinLiberty.php
@@ -1,11 +1,11 @@
 <?php
 // @codingStandardsIgnoreLine
 class SkinLiberty extends SkinTemplate{
-    // @codingStandardsIgnoreStart
-    public $skinname = 'liberty';
-    public $stylename = 'Liberty';
-    public $template = 'LibertyTemplate';
-    // @codingStandardsIgnoreEnd
+	// @codingStandardsIgnoreStart
+	public $skinname = 'liberty';
+	public $stylename = 'Liberty';
+	public $template = 'LibertyTemplate';
+	// @codingStandardsIgnoreEnd
 
 	/**
 	 * Page initialize.
@@ -13,8 +13,8 @@ class SkinLiberty extends SkinTemplate{
 	 * @param OutputPage $out OutputPage
 	 */
 	public function initPage( OutputPage $out ) {
-        // @codingStandardsIgnoreLine
-        global $wgSitename, $wgTwitterAccount, $wgLanguageCode, $wgNaverVerification, $wgLogo, $wgLibertyEnableLiveRC, $wgLibertyAdSetting, $wgLibertyAdGroup;
+		// @codingStandardsIgnoreLine
+		global $wgSitename, $wgTwitterAccount, $wgLanguageCode, $wgNaverVerification, $wgLogo, $wgLibertyEnableLiveRC, $wgLibertyAdSetting, $wgLibertyAdGroup;
 
 		$user = $this->getUser();
 		/* uncomment if needs to use UserGroupManager
@@ -27,8 +27,8 @@ class SkinLiberty extends SkinTemplate{
 		$optionSecondColor = $user->getOption( 'liberty-color-second' );
 
 		$mainColor = $optionMainColor ? $optionMainColor : $GLOBALS['wgLibertyMainColor'];
-        // @codingStandardsIgnoreLine
-        $tempSecondColor = isset($GLOBALS['wgLibertySecondColor']) ? $GLOBALS['wgLibertySecondColor'] : '#' . strtoupper(dechex(hexdec(substr($mainColor, 1, 6)) - hexdec('1A1415')));
+		// @codingStandardsIgnoreLine
+		$tempSecondColor = isset( $GLOBALS['wgLibertySecondColor'] ) ? $GLOBALS['wgLibertySecondColor'] : '#' . strtoupper( dechex( hexdec( substr( $mainColor, 1, 6 ) ) - hexdec( '1A1415' ) ) );
 		$secondColor = $optionSecondColor ? $optionSecondColor : $tempSecondColor;
 		$ogLogo = isset( $GLOBALS['wgLibertyOgLogo'] ) ? $GLOBALS['wgLibertyOgLogo'] : $wgLogo;
 		if ( !preg_match( '/^((?:(?:http(?:s)?)?:)?\/\/(?:.{4,}))$/i', $ogLogo ) ) {
@@ -101,8 +101,9 @@ class SkinLiberty extends SkinTemplate{
 
 		$out->addModules( $modules );
 
-        // @codingStandardsIgnoreStart
-        $out->addInlineStyle(".Liberty .nav-wrapper,
+		// @codingStandardsIgnoreStart
+		$out->addInlineStyle(
+			".Liberty .nav-wrapper,
 		.Liberty .nav-wrapper .navbar .form-inline .btn:hover,
 		.Liberty .nav-wrapper .navbar .form-inline .btn:focus,
 		.Liberty .content-wrapper .liberty-sidebar .live-recent-wrapper .live-recent .live-recent-header .nav .nav-item .nav-link.active::before,
@@ -139,81 +140,94 @@ class SkinLiberty extends SkinTemplate{
 		.Liberty .content-wrapper #liberty-bottombtn,
 		.Liberty .content-wrapper #liberty-bottombtn:hover {
 			background-color: $mainColor;
-		}");
+		}"
+		);
 
-        // layout settings
-        $LibertyUserWidthSettings = $user->getOption('liberty-layout-width');
-        $LibertyUserSidebarSettings = $user->getOption('liberty-layout-sidebar');
-        $LibertyUserNavbarSettings = $user->getOption('liberty-layout-navfix');
-        $LibertyUsercontrolbarSettings = $user->getOption('liberty-layout-controlbar');
+		// layout settings
+		$LibertyUserWidthSettings = $user->getOption( 'liberty-layout-width' );
+		$LibertyUserSidebarSettings = $user->getOption( 'liberty-layout-sidebar' );
+		$LibertyUserNavbarSettings = $user->getOption( 'liberty-layout-navfix' );
+		$LibertyUsercontrolbarSettings = $user->getOption( 'liberty-layout-controlbar' );
 
 
-        if (isset($LibertyUserNavbarSettings) && $LibertyUserNavbarSettings) {
-            $out->addInlineStyle(
-                ".navbar-fixed-top {
+		if ( isset( $LibertyUserNavbarSettings ) && $LibertyUserNavbarSettings ) {
+			$out->addInlineStyle(
+				".navbar-fixed-top {
 					position: absolute;
 				}"
-            );
-        };
+			);
+		}
 
-        if (isset($LibertyUserSidebarSettings) && $LibertyUserSidebarSettings) {
-            $out->addInlineStyle(
-                ".Liberty .content-wrapper .liberty-content {
+		if ( isset( $LibertyUserSidebarSettings ) && $LibertyUserSidebarSettings ) {
+			$out->addInlineStyle(
+				".Liberty .content-wrapper .liberty-content {
 					margin-right: 0;
 				}"
-            );
-        };
+			);
+		}
 
-        if ($LibertyUserWidthSettings != null) {
-            $out->addInlineStyle(
-                ".Liberty .content-wrapper {
+		if ( $LibertyUserWidthSettings !== null ) {
+			$out->addInlineStyle(
+				".Liberty .content-wrapper {
 					max-width: $LibertyUserWidthSettings;
 				}
 
 				.Liberty .nav-wrapper .navbar {
 					max-width: $LibertyUserWidthSettings;
 				}"
-            );
-        }
+			);
+		}
 
-        if (isset($LibertyUsercontrolbarSettings) && $LibertyUsercontrolbarSettings) {
-            $out->addInlineStyle(
-                ".Liberty .content-wrapper #liberty-bottombtn {
+		if ( isset( $LibertyUsercontrolbarSettings ) && $LibertyUsercontrolbarSettings ) {
+			$out->addInlineStyle(
+				".Liberty .content-wrapper #liberty-bottombtn {
 					display: none;
 				}"
-            );
-        };
+			);
+		}
 
-        // 폰트 설정
-        $LibertyUserFontSettings = $user->getOption('liberty-font');
-        if ($LibertyUserFontSettings != null) {
-            $out->addInlineStyle(
-                "body, h1, h2, h3, h4, h5, h6, b {
+		// 폰트 설정
+		$LibertyUserFontSettings = $user->getOption( 'liberty-font' );
+		if ( $LibertyUserFontSettings !== null ) {
+			$out->addInlineStyle(
+				"body, h1, h2, h3, h4, h5, h6, b {
 					font-family: $LibertyUserFontSettings;
 				}"
-            );
-        }
+			);
+		}
 
-        // Ads setting
-        if (isset($wgLibertyAdSetting['client']) && $wgLibertyAdSetting['client']) {
-            // change ads option by rights
-            if (isset($wgLibertyAdGroup) && $wgLibertyAdGroup == 'differ') {
-                if (isset($wgLibertyAdSetting['header']) && $wgLibertyAdSetting['header'] && $user->getOption('liberty-ads-header')) {
-                    $wgLibertyAdSetting['header'] == null;
-                }
-                if (isset($wgLibertyAdSetting['right']) && $wgLibertyAdSetting['right'] && $user->getOption('liberty-ads-right')) {
-                    $wgLibertyAdSetting['right'] == null;
-                }
-                if (isset($wgLibertyAdSetting['bottom']) && $wgLibertyAdSetting['bottom'] && $user->getOption('liberty-ads-bottom')) {
-                    $wgLibertyAdSetting['bottom'] == null;
-                }
-                if (isset($wgLibertyAdSetting['belowarticle']) && $wgLibertyAdSetting['belowarticle'] && $user->getOption('liberty-ads-belowarticle')) {
-                    $wgLibertyAdSetting['belowarticle'] == null;
-                }
-            }
-        }
+		// Ads setting
+		if ( isset( $wgLibertyAdSetting['client'] ) && $wgLibertyAdSetting['client'] ) {
+			// change ads option by rights
+			if ( isset( $wgLibertyAdGroup ) && $wgLibertyAdGroup == 'differ' ) {
+				if (
+					isset( $wgLibertyAdSetting['header'] ) && $wgLibertyAdSetting['header'] &&
+					$user->getOption( 'liberty-ads-header' )
+				) {
+					$wgLibertyAdSetting['header'] == null;
+				}
+				if (
+					isset( $wgLibertyAdSetting['right'] ) && $wgLibertyAdSetting['right'] &&
+					$user->getOption( 'liberty-ads-right' )
+				) {
+					$wgLibertyAdSetting['right'] == null;
+				}
+				if (
+					isset( $wgLibertyAdSetting['bottom'] ) && $wgLibertyAdSetting['bottom'] &&
+					$user->getOption( 'liberty-ads-bottom' )
+				) {
+					$wgLibertyAdSetting['bottom'] == null;
+				}
+				if (
+					isset( $wgLibertyAdSetting['belowarticle'] ) && $wgLibertyAdSetting['belowarticle'] &&
+					$user->getOption( 'liberty-ads-belowarticle' )
+				) {
+					$wgLibertyAdSetting['belowarticle'] == null;
+				}
+			}
+		}
 
-        $LibertyDarkCss = "body, .Liberty, .dropdown-menu, .dropdown-item, .Liberty .nav-wrapper .navbar .form-inline .btn, .Liberty .content-wrapper .liberty-sidebar .live-recent-wrapper .live-recent .live-recent-header .nav .nav-item .nav-link.active, .Liberty .content-wrapper .liberty-content .liberty-content-main table.wikitable tr > th, .Liberty .content-wrapper .liberty-content .liberty-content-main table.wikitable tr > td, table.mw_metadata th, .Liberty .content-wrapper .liberty-content .liberty-content-main table.infobox th, #preferences fieldset:not(.prefsection), #preferences div.mw-prefs-buttons, .navbox, .navbox-subgroup, .navbox > tbody > tr:nth-child(even) > .navbox-list {
+		$LibertyDarkCss = "body, .Liberty, .dropdown-menu, .dropdown-item, .Liberty .nav-wrapper .navbar .form-inline .btn, .Liberty .content-wrapper .liberty-sidebar .live-recent-wrapper .live-recent .live-recent-header .nav .nav-item .nav-link.active, .Liberty .content-wrapper .liberty-content .liberty-content-main table.wikitable tr > th, .Liberty .content-wrapper .liberty-content .liberty-content-main table.wikitable tr > td, table.mw_metadata th, .Liberty .content-wrapper .liberty-content .liberty-content-main table.infobox th, #preferences fieldset:not(.prefsection), #preferences div.mw-prefs-buttons, .navbox, .navbox-subgroup, .navbox > tbody > tr:nth-child(even) > .navbox-list {
 			background-color: #000;
 			color: #DDD;
 		}
@@ -240,13 +254,15 @@ class SkinLiberty extends SkinTemplate{
 		.flow-ui-navigationWidget { color: #FFF; }
 		.Liberty .content-wrapper .liberty-content .liberty-content-main .toccolours, .Liberty .content-wrapper .liberty-content .liberty-content-main .toc ul, .Liberty .content-wrapper .liberty-content .liberty-content-main .toc li { background-color: #000; }
 		.Liberty .content-wrapper .liberty-content .liberty-content-main .toc .toctitle { background-color: #1F2023; }";
-        $LibertyUserDarkSetting = $user->getOption('liberty-dark');
-        if ($LibertyUserDarkSetting === 'dark') {
-            $out->addInlineStyle($LibertyDarkCss);
-        } elseif ($LibertyUserDarkSetting === null) {
-            $out->addInlineStyle("@media (prefers-color-scheme: dark) { $LibertyDarkCss }");
-        }
-        // @codingStandardsIgnoreEnd
+
+		$LibertyUserDarkSetting = $user->getOption( 'liberty-dark' );
+		if ( $LibertyUserDarkSetting === 'dark' ) {
+			$out->addInlineStyle( $LibertyDarkCss );
+		} elseif ( $LibertyUserDarkSetting === null ) {
+			$out->addInlineStyle( "@media (prefers-color-scheme: dark) { $LibertyDarkCss }" );
+		}
+
+		// @codingStandardsIgnoreEnd
 		$this->setupCss( $out );
 	}
 
@@ -258,26 +274,26 @@ class SkinLiberty extends SkinTemplate{
 	public function setupCss( OutputPage $out ) {
 		$out->addHeadItem(
 			'font-awesome',
-            // @codingStandardsIgnoreLine
-            '<link rel="stylesheet" href="//use.fontawesome.com/releases/v5.13.1/css/all.css" />'
+			// @codingStandardsIgnoreLine
+			'<link rel="stylesheet" href="//use.fontawesome.com/releases/v5.13.1/css/all.css" />'
 		);
 
 		$out->addHeadItem(
 			'font-awesome-shims',
-            // @codingStandardsIgnoreLine
-            '<link rel="stylesheet" href="//use.fontawesome.com/releases/v5.13.1/css/v4-shims.css" />'
+			// @codingStandardsIgnoreLine
+			'<link rel="stylesheet" href="//use.fontawesome.com/releases/v5.13.1/css/v4-shims.css" />'
 		);
 
 		$out->addHeadItem(
 			'webfonts',
-            // @codingStandardsIgnoreLine
-            '<link href="https://fonts.googleapis.com/css?family=Dokdo|Gaegu|Nanum+Gothic|Nanum+Gothic+Coding|Nanum+Myeongjo|Noto+Serif+KR|Noto+Sans+KR&display=swap&subset=korean" rel="stylesheet">'
+			// @codingStandardsIgnoreLine
+			'<link href="https://fonts.googleapis.com/css?family=Dokdo|Gaegu|Nanum+Gothic|Nanum+Gothic+Coding|Nanum+Myeongjo|Noto+Serif+KR|Noto+Sans+KR&display=swap&subset=korean" rel="stylesheet">'
 		);
 
 		$out->addHeadItem(
 			'share-api-polyfill',
-            // @codingStandardsIgnoreLine
-            '<script async src="https://unpkg.com/share-api-polyfill/dist/share-min.js"></script>'
+			// @codingStandardsIgnoreLine
+			'<script async src="https://unpkg.com/share-api-polyfill/dist/share-min.js"></script>'
 		);
 		$out->addModuleStyles( [ 'skins.liberty.styles' ] );
 	}

--- a/css/default.css
+++ b/css/default.css
@@ -3,21 +3,21 @@
 
 /* HTML Tag */
 * {
-  outline: none;
+	outline: none;
 }
 
 input:hover,
 button:hover,
 select:hover {
-  transition: 0.3s;
+	transition: 0.3s;
 }
 
 html {
-  font-size: 15px;
+	font-size: 15px;
 }
 
 body {
-  font-size: 0.95rem;
+	font-size: 0.95rem;
 }
 
 body,
@@ -27,10 +27,10 @@ h3,
 h4,
 h5,
 h6 {
-  font-family: "Apple SD Gothic Neo", "Spoqa Han Sans", "SpoqaHanSans",
-    "Noto Sans KR", "Noto Sans", "Noto Sans CJK KR", "NanumBarunGothic",
-    "Nanum Gothic", "KoPub Dotum", "Malgun Gothic", "맑은 고딕", sans-serif;
-  margin: 0;
+	font-family: "Apple SD Gothic Neo", "Spoqa Han Sans", "SpoqaHanSans",
+		"Noto Sans KR", "Noto Sans", "Noto Sans CJK KR", "NanumBarunGothic",
+		"Nanum Gothic", "KoPub Dotum", "Malgun Gothic", "맑은 고딕", sans-serif;
+	margin: 0;
 }
 
 h1,
@@ -40,999 +40,781 @@ h4,
 h5,
 h6,
 b {
-  font-family: "Apple SD Gothic Neo", "Spoqa Han Sans", "SpoqaHanSans",
-    "Noto Sans KR", "Noto Sans", "Noto Sans CJK KR", "NanumBarunGothic",
-    "Nanum Gothic", "KoPub Dotum", "Malgun Gothic", "맑은 고딕", sans-serif;
+	font-family: "Apple SD Gothic Neo", "Spoqa Han Sans", "SpoqaHanSans",
+		"Noto Sans KR", "Noto Sans", "Noto Sans CJK KR", "NanumBarunGothic",
+		"Nanum Gothic", "KoPub Dotum", "Malgun Gothic", "맑은 고딕", sans-serif;
 }
 
 input[type="password"] {
-  font-family: sans-serif;
+	font-family: sans-serif;
 }
 
 h1 {
-  font-size: 2rem;
+	font-size: 2rem;
 }
 
 h2 {
-  font-size: 1.8rem;
+	font-size: 1.8rem;
 }
 
 h3 {
-  font-size: 1.6rem;
+	font-size: 1.6rem;
 }
 
 h4 {
-  font-size: 1.5rem;
+	font-size: 1.5rem;
 }
 
 h5 {
-  font-size: 1.3rem;
+	font-size: 1.3rem;
 }
 
 h6 {
-  font-size: 1.1rem;
+	font-size: 1.1rem;
 }
 
 ol,
 ul,
 p {
-  margin: 0;
-  padding: 0;
+	margin: 0;
+	padding: 0;
 }
 
 p {
-  margin-bottom: 0.8rem;
+	margin-bottom: 0.8rem;
 }
 
 ol,
 .mw-content-ltr ol,
 .mw-content-rtl .mw-content-ltr ol {
-  margin: 0;
-  margin-left: 2.2rem;
-  margin-right: 1rem;
-  list-style-image: none;
+	margin: 0;
+	margin-left: 2.2rem;
+	margin-right: 1rem;
+	list-style-image: none;
 }
 
 pre {
-  display: block;
-  color: #333;
-  word-break: break-all;
-  word-wrap: break-word;
-  background-color: #f5f8fa;
-  border: 1px solid #e1e8ed;
-  border-radius: 0.35rem;
-  padding: 0.8rem;
+	display: block;
+	color: #333;
+	word-break: break-all;
+	word-wrap: break-word;
+	background-color: #f5f8fa;
+	border: 1px solid #e1e8ed;
+	border-radius: 0.35rem;
+	padding: 0.8rem;
 }
 
 a:focus {
-  outline: 0;
+	outline: 0;
 }
 
 p {
-  overflow-wrap: break-word;
+	overflow-wrap: break-word;
 }
 
 ul {
-  list-style-image: url(data:image/svg+xml,%3C%3Fxml%20version%3D%221.0%22%20encoding%3D%22UTF-8%22%3F%3E%0A%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20version%3D%221.1%22%20width%3D%225%22%20height%3D%2213%22%3E%0A%3Ccircle%20cx%3D%222.5%22%20cy%3D%229.5%22%20r%3D%222.5%22%20fill%3D%22%23373a3c%22%2F%3E%0A%3C%2Fsvg%3E%0A);
+	list-style-image: url(data:image/svg+xml,%3C%3Fxml%20version%3D%221.0%22%20encoding%3D%22UTF-8%22%3F%3E%0A%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20version%3D%221.1%22%20width%3D%225%22%20height%3D%2213%22%3E%0A%3Ccircle%20cx%3D%222.5%22%20cy%3D%229.5%22%20r%3D%222.5%22%20fill%3D%22%23373a3c%22%2F%3E%0A%3C%2Fsvg%3E%0A);
 }
 
 img {
-  max-width: 100%;
-  height: auto;
-  margin: 0;
+	max-width: 100%;
+	height: auto;
+	margin: 0;
 }
 
 th[rowspan],
 td[rowspan] {
-  position: relative;
+	position: relative;
 }
 
 th[rowspan]:after,
 td[rowspan]:after {
-  content: "";
-  position: absolute;
-  top: 0;
-  right: -1px;
-  width: 1px;
-  height: 100%;
-  /*background: #e0e0e0;*/
+	content: "";
+	position: absolute;
+	top: 0;
+	right: -1px;
+	width: 1px;
+	height: 100%;
+	/*background: #e0e0e0;*/
 }
 
 input[type="search"] {
-  -webkit-appearance: none;
-  /* Removes some iOS CSS Settings */
+	-webkit-appearance: none;
+	/* Removes some iOS CSS Settings */
 }
 
 textarea {
-  width: 100%;
-  border: 1px solid #e1e8ed;
-  padding: 0.5rem;
+	width: 100%;
+	border: 1px solid #e1e8ed;
+	padding: 0.5rem;
 }
 
 hr {
-  border-top: 1px solid #e1e8ed;
+	border-top: 1px solid #e1e8ed;
 }
 
 html input[type="button"]:hover,
 html input[type="submit"]:hover,
 button:hover {
-  background-color: #449d44;
+	background-color: #449d44;
 }
 
 label {
-  vertical-align: middle;
-  word-break: keep-all;
+	vertical-align: middle;
+	word-break: keep-all;
 }
 
 del,
 s,
 strike {
-  color: #808080;
+	color: #808080;
 }
 /* HTML Tag End */
 
 /* Background Color */
 .Liberty {
-  background-color: #f5f5f5;
+	background-color: #f5f5f5;
 }
-/* Background Color End*/
+/* Background Color End */
 
 /* Content width, alian center */
 .Liberty .nav-wrapper .navbar,
 .Liberty .content-wrapper {
-  max-width: 1200px;
-  margin: 0 auto;
+	max-width: 1200px;
+	margin: 0 auto;
 }
 /* Content width, alian center End */
 
 /* Nav */
 .Liberty .nav-wrapper {
-  min-height: 2.8rem;
-  z-index: 1001;
-  box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.16), 0 2px 10px 0 rgba(0, 0, 0, 0.12);
+	min-height: 2.8rem;
+	z-index: 1001;
+	box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.16), 0 2px 10px 0 rgba(0, 0, 0, 0.12);
 }
 
 .Liberty .nav-wrapper .navbar {
-  padding: 0 1rem;
-  border: 0;
-  border-radius: 0;
+	padding: 0 1rem;
+	border: 0;
+	border-radius: 0;
 }
 
 .Liberty .nav-wrapper .navbar .navbar-brand {
-  height: 2.8rem;
-  width: 6.6rem;
-  background: transparent url(../img/logo.png) no-repeat scroll left center/auto
-    1.9rem;
-  padding: 0;
-  margin: 0;
+	height: 2.8rem;
+	width: 6.6rem;
+	background: transparent url(../img/logo.png) no-repeat scroll left center/auto
+		1.9rem;
+	padding: 0;
+	margin: 0;
 }
 
 .Liberty .nav-wrapper .navbar .navbar-nav .nav-item {
-  margin: 0;
+	margin: 0;
 }
 
 .Liberty .nav-wrapper .navbar .navbar-nav .nav-item .fa,
 .Liberty .nav-wrapper .navbar .navbar-nav .nav-item .fas,
 .Liberty .nav-wrapper .navbar .navbar-nav .nav-item .far {
-  margin-right: 0.5rem;
-  font-size: 1rem;
+	margin-right: 0.5rem;
+	font-size: 1rem;
 }
 
 .Liberty .nav-wrapper .navbar .navbar-nav .nav-item .nav-link {
-  color: #fff;
-  font-size: 1rem;
-  padding: 0.7rem 0.8rem;
-  line-height: 1.4rem;
+	color: #fff;
+	font-size: 1rem;
+	padding: 0.7rem 0.8rem;
+	line-height: 1.4rem;
 }
 
 .Liberty .nav-wrapper .navbar .navbar-nav .nav-item .nav-link:hover,
 .Liberty .nav-wrapper .navbar .navbar-nav .nav-item .nav-link:focus {
-  transition: 0.3s;
+	transition: 0.3s;
 }
 
 .Liberty .nav-wrapper .navbar .navbar-nav .nav-item .dropdown-menu {
-  margin-top: 0;
-  border-top-left-radius: 0;
-  border-top-right-radius: 0;
+	margin-top: 0;
+	border-top-left-radius: 0;
+	border-top-right-radius: 0;
 }
 
 .Liberty .nav-wrapper .navbar .navbar-nav .nav-item .dropdown-toggle::after {
-  margin-right: 0;
-  margin-left: 0.35rem;
+	margin-right: 0;
+	margin-left: 0.35rem;
 }
 
 .Liberty .nav-wrapper .navbar .form-inline {
-  padding: 0.4rem 0;
-  float: right;
+	padding: 0.4rem 0;
+	float: right;
 }
 
 .Liberty .nav-wrapper .navbar .form-inline .form-control {
-  font-size: 0.8rem;
-  height: 2rem;
-  width: 10.8rem;
-  padding: 0.2rem 0.4rem;
-  border-color: #ccc;
-  border-radius: 0;
-  border-top-left-radius: 0.35rem;
-  border-bottom-left-radius: 0.35rem;
+	font-size: 0.8rem;
+	height: 2rem;
+	width: 10.8rem;
+	padding: 0.2rem 0.4rem;
+	border-color: #ccc;
+	border-radius: 0;
+	border-top-left-radius: 0.35rem;
+	border-bottom-left-radius: 0.35rem;
 }
 
 .Liberty .nav-wrapper .navbar .form-inline .btn {
-  height: 2rem;
-  color: #4f5b63;
-  padding: 0.2rem 0.4rem;
-  line-height: 22px;
+	height: 2rem;
+	color: #4f5b63;
+	padding: 0.2rem 0.4rem;
+	line-height: 22px;
 }
 
 .Liberty .nav-wrapper .navbar .form-inline .btn:hover,
 .Liberty .nav-wrapper .navbar .form-inline .btn:focus {
-  color: #fff;
-  outline: 0;
+	color: #fff;
+	outline: 0;
 }
 
 .Liberty .nav-wrapper .navbar .form-inline .btn .fa,
 .Liberty .nav-wrapper .navbar .form-inline .btn .fas,
 .Liberty .nav-wrapper .navbar .form-inline .btn .far {
-  width: 0.9rem;
+	width: 0.9rem;
 }
 
 .Liberty .nav-wrapper .navbar .navbar-login {
-  float: right;
-  padding-left: 0.8rem;
+	float: right;
+	padding-left: 0.8rem;
 }
 
 .Liberty .nav-wrapper .navbar .navbar-login .fa,
 .Liberty .nav-wrapper .navbar .navbar-login .fas,
 .Liberty .nav-wrapper .navbar .navbar-login .far {
-  color: #fff;
-  padding: 0.7rem 0;
-  font-size: 1.5rem;
-  line-height: 1.4rem;
+	color: #fff;
+	padding: 0.7rem 0;
+	font-size: 1.5rem;
+	line-height: 1.4rem;
 }
 
 .Liberty .nav-wrapper .navbar .navbar-login .login-menu {
-  float: left;
-  cursor: pointer;
-  padding: 0.4rem 0;
+	float: left;
+	cursor: pointer;
+	padding: 0.4rem 0;
 }
 
 .Liberty .nav-wrapper .navbar .navbar-login .login-menu > a:after {
-  display: none;
+	display: none;
 }
 
 .Liberty .nav-wrapper .navbar .navbar-login .profile-img {
-  width: 2rem;
-  height: 2rem;
-  border-radius: 0.35rem;
-  margin: 0;
-  border: 1px solid #e1e8ed;
+	width: 2rem;
+	height: 2rem;
+	border-radius: 0.35rem;
+	margin: 0;
+	border: 1px solid #e1e8ed;
 }
 
 .Liberty .nav-wrapper .navbar .navbar-login .logout-btn {
-  margin-left: 0.8rem;
-  display: inline-block;
+	margin-left: 0.8rem;
+	display: inline-block;
 }
 
 .Liberty .nav-wrapper .navbar .navbar-login .login-dropdown-menu {
-  top: 120%;
-  right: -1rem;
-  z-index: 1002;
+	top: 120%;
+	right: -1rem;
+	z-index: 1002;
 }
 
 .Liberty .nav-wrapper .navbar .navbar-login .login-dropdown-menu:before,
 .Liberty .nav-wrapper .navbar .navbar-login .login-dropdown-menu:after {
-  bottom: 100%;
-  border: solid transparent;
-  content: " ";
-  position: absolute;
-  left: 0;
-  right: auto;
+	bottom: 100%;
+	border: solid transparent;
+	content: " ";
+	position: absolute;
+	left: 0;
+	right: auto;
 }
 
 .Liberty .nav-wrapper .navbar .navbar-login .login-dropdown-menu:before {
-  border-bottom-color: #e1e8ed;
-  border-width: 0.8rem;
-  left: auto;
-  right: 1.15rem;
+	border-bottom-color: #e1e8ed;
+	border-width: 0.8rem;
+	left: auto;
+	right: 1.15rem;
 }
 
 .Liberty .nav-wrapper .navbar .navbar-login .login-dropdown-menu:after {
-  border-bottom-color: #fff;
-  border-width: 0.78rem;
-  left: auto;
-  right: 1.15rem;
+	border-bottom-color: #fff;
+	border-width: 0.78rem;
+	left: auto;
+	right: 1.15rem;
 }
 
 .dropdown-submenu {
-  position: relative;
-  min-width: 158px;
+	position: relative;
+	min-width: 158px;
 }
 /* Nav End */
 
 /* Right menu */
 .Liberty .content-wrapper .liberty-sidebar {
-  float: right;
-  width: 15rem;
-  position: relative;
+	float: right;
+	width: 15rem;
+	position: relative;
 }
 
 .Liberty .content-wrapper .liberty-sidebar .live-recent-wrapper {
-  z-index: 1;
+	z-index: 1;
 }
 
 .Liberty .content-wrapper .liberty-sidebar .live-recent-wrapper .live-recent {
-  width: 15rem;
+	width: 15rem;
 }
 
-.Liberty
-  .content-wrapper
-  .liberty-sidebar
-  .live-recent-wrapper
-  .live-recent
-  .live-recent-header
-  .nav {
-  border: 0;
+.Liberty .content-wrapper .liberty-sidebar .live-recent-wrapper .live-recent .live-recent-header .nav {
+	border: 0;
 }
 
-.Liberty
-  .content-wrapper
-  .liberty-sidebar
-  .live-recent-wrapper
-  .live-recent
-  .live-recent-header
-  .nav
-  .nav-item {
-  width: 7.5rem;
-  border: 1px solid #e1e8ed;
-  border-top-left-radius: 0.35rem;
-  background-color: #f5f8fa;
+.Liberty .content-wrapper .liberty-sidebar .live-recent-wrapper .live-recent .live-recent-header .nav .nav-item {
+	width: 7.5rem;
+	border: 1px solid #e1e8ed;
+	border-top-left-radius: 0.35rem;
+	background-color: #f5f8fa;
 }
 
-.Liberty
-  .content-wrapper
-  .liberty-sidebar
-  .live-recent-wrapper
-  .live-recent
-  .live-recent-header
-  .nav
-  .nav-item
-  + .nav-item {
-  margin-left: 0;
-  border-left: 0;
-  border-top-left-radius: 0;
-  border-top-right-radius: 0.35rem;
+.Liberty .content-wrapper .liberty-sidebar .live-recent-wrapper .live-recent .live-recent-header .nav .nav-item + .nav-item {
+	margin-left: 0;
+	border-left: 0;
+	border-top-left-radius: 0;
+	border-top-right-radius: 0.35rem;
 }
 
-.Liberty
-  .content-wrapper
-  .liberty-sidebar
-  .live-recent-wrapper
-  .live-recent
-  .live-recent-header
-  .nav
-  .nav-item
-  .nav-link {
-  border: 0;
-  border-radius: 0;
-  border-top-left-radius: 0.35rem;
-  text-align: center;
-  padding-top: 0.6rem;
-  padding-bottom: 0.6rem;
-  color: #6e7478;
-  position: relative;
+.Liberty .content-wrapper .liberty-sidebar .live-recent-wrapper .live-recent .live-recent-header .nav .nav-item .nav-link {
+	border: 0;
+	border-radius: 0;
+	border-top-left-radius: 0.35rem;
+	text-align: center;
+	padding-top: 0.6rem;
+	padding-bottom: 0.6rem;
+	color: #6e7478;
+	position: relative;
 }
 
-.Liberty
-  .content-wrapper
-  .liberty-sidebar
-  .live-recent-wrapper
-  .live-recent
-  .live-recent-header
-  .nav
-  .nav-item
-  + .nav-item
-  .nav-link {
-  border-top-left-radius: 0;
-  border-top-right-radius: 0.35rem;
+.Liberty .content-wrapper .liberty-sidebar .live-recent-wrapper .live-recent .live-recent-header .nav .nav-item + .nav-item .nav-link {
+	border-top-left-radius: 0;
+	border-top-right-radius: 0.35rem;
 }
 
-.Liberty
-  .content-wrapper
-  .liberty-sidebar
-  .live-recent-wrapper
-  .live-recent
-  .live-recent-header
-  .nav
-  .nav-item
-  .nav-link.active,
-.Liberty
-  .content-wrapper
-  .liberty-sidebar
-  .live-recent-wrapper
-  .live-recent
-  .live-recent-header
-  .nav
-  .nav-item
-  .nav-link:hover,
-.Liberty
-  .content-wrapper
-  .liberty-sidebar
-  .live-recent-wrapper
-  .live-recent
-  .live-recent-header
-  .nav
-  .nav-item
-  .nav-link:focus,
-.Liberty
-  .content-wrapper
-  .liberty-sidebar
-  .live-recent-wrapper
-  .live-recent
-  .live-recent-header
-  .nav
-  .nav-item
-  .nav-link:active {
-  color: #373a3c;
-  background-color: #fff;
+.Liberty .content-wrapper .liberty-sidebar .live-recent-wrapper .live-recent .live-recent-header .nav .nav-item .nav-link.active,
+.Liberty .content-wrapper .liberty-sidebar .live-recent-wrapper .live-recent .live-recent-header .nav .nav-item .nav-link:hover,
+.Liberty .content-wrapper .liberty-sidebar .live-recent-wrapper .live-recent .live-recent-header .nav .nav-item .nav-link:focus,
+.Liberty .content-wrapper .liberty-sidebar .live-recent-wrapper .live-recent .live-recent-header .nav .nav-item .nav-link:active {
+	color: #373a3c;
+	background-color: #fff;
 }
 
-.Liberty
-  .content-wrapper
-  .liberty-sidebar
-  .live-recent-wrapper
-  .live-recent
-  .live-recent-header
-  .nav
-  .nav-item
-  .nav-link.active::before,
-.Liberty
-  .content-wrapper
-  .liberty-sidebar
-  .live-recent-wrapper
-  .live-recent
-  .live-recent-header
-  .nav
-  .nav-item
-  .nav-link:hover::before,
-.Liberty
-  .content-wrapper
-  .liberty-sidebar
-  .live-recent-wrapper
-  .live-recent
-  .live-recent-header
-  .nav
-  .nav-item
-  .nav-link:focus::before,
-.Liberty
-  .content-wrapper
-  .liberty-sidebar
-  .live-recent-wrapper
-  .live-recent
-  .live-recent-header
-  .nav
-  .nav-item
-  .nav-link:active::before {
-  position: absolute;
-  left: -1px;
-  bottom: -1px;
-  content: " ";
-  width: 7.5rem;
-  display: block;
+.Liberty .content-wrapper .liberty-sidebar .live-recent-wrapper .live-recent .live-recent-header .nav .nav-item .nav-link.active::before,
+.Liberty .content-wrapper .liberty-sidebar .live-recent-wrapper .live-recent .live-recent-header .nav .nav-item .nav-link:hover::before,
+.Liberty .content-wrapper .liberty-sidebar .live-recent-wrapper .live-recent .live-recent-header .nav .nav-item .nav-link:focus::before,
+.Liberty .content-wrapper .liberty-sidebar .live-recent-wrapper .live-recent .live-recent-header .nav .nav-item .nav-link:active::before {
+	position: absolute;
+	left: -1px;
+	bottom: -1px;
+	content: " ";
+	width: 7.5rem;
+	display: block;
 }
 
-.Liberty
-  .content-wrapper
-  .liberty-sidebar
-  .live-recent-wrapper
-  .live-recent
-  .live-recent-content {
-  background-color: #fff;
-  border: 1px solid #e1e8ed;
-  border-top: 0;
-  z-index: 1;
+.Liberty .content-wrapper .liberty-sidebar .live-recent-wrapper .live-recent .live-recent-content {
+	background-color: #fff;
+	border: 1px solid #e1e8ed;
+	border-top: 0;
+	z-index: 1;
 }
 
-.Liberty
-  .content-wrapper
-  .liberty-sidebar
-  .live-recent-wrapper
-  .live-recent
-  .live-recent-content
-  .live-recent-list {
-  list-style: none;
+.Liberty .content-wrapper .liberty-sidebar .live-recent-wrapper .live-recent .live-recent-content .live-recent-list {
+	list-style: none;
 }
 
-.Liberty
-  .content-wrapper
-  .liberty-sidebar
-  .live-recent-wrapper
-  .live-recent
-  .live-recent-content
-  .live-recent-list
-  li {
-  border-bottom: 1px solid #e1e8ed;
-  padding: 0.2rem 0.6rem;
+.Liberty .content-wrapper .liberty-sidebar .live-recent-wrapper .live-recent .live-recent-content .live-recent-list li {
+	border-bottom: 1px solid #e1e8ed;
+	padding: 0.2rem 0.6rem;
 }
 
-.Liberty
-  .content-wrapper
-  .liberty-sidebar
-  .live-recent-wrapper
-  .live-recent
-  .live-recent-content
-  .live-recent-list
-  li:last-child {
-  border-bottom: none;
+.Liberty .content-wrapper .liberty-sidebar .live-recent-wrapper .live-recent .live-recent-content .live-recent-list li:last-child {
+	border-bottom: none;
 }
 
-.Liberty
-  .content-wrapper
-  .liberty-sidebar
-  .live-recent-wrapper
-  .live-recent
-  .live-recent-content
-  .live-recent-list
-  .recent-item {
-  font-size: 0.8rem;
-  color: #373a3c;
+.Liberty .content-wrapper .liberty-sidebar .live-recent-wrapper .live-recent .live-recent-content .live-recent-list .recent-item {
+	font-size: 0.8rem;
+	color: #373a3c;
 }
 
-.Liberty
-  .content-wrapper
-  .liberty-sidebar
-  .live-recent-wrapper
-  .live-recent
-  .live-recent-content
-  .live-recent-list
-  .recent-item
-  .new {
-  font-size: 0.8rem;
-  color: #b73333;
+.Liberty .content-wrapper .liberty-sidebar .live-recent-wrapper .live-recent .live-recent-content .live-recent-list .recent-item .new {
+	font-size: 0.8rem;
+	color: #b73333;
 }
 
-.Liberty
-  .content-wrapper
-  .liberty-sidebar
-  .live-recent-wrapper
-  .live-recent
-  .live-recent-footer {
-  background-color: #f5f8fa;
-  border: 1px solid #e1e8ed;
-  border-top: 0;
-  border-bottom-left-radius: 0.35rem;
-  border-bottom-right-radius: 0.35rem;
-  text-align: right;
-  padding: 0.4rem 0.6rem;
+.Liberty .content-wrapper .liberty-sidebar .live-recent-wrapper .live-recent .live-recent-footer {
+	background-color: #f5f8fa;
+	border: 1px solid #e1e8ed;
+	border-top: 0;
+	border-bottom-left-radius: 0.35rem;
+	border-bottom-right-radius: 0.35rem;
+	text-align: right;
+	padding: 0.4rem 0.6rem;
 }
 
-.Liberty
-  .content-wrapper
-  .liberty-sidebar
-  .live-recent-wrapper
-  .live-recent
-  .live-recent-footer
-  .label {
-  padding: 0.4rem;
-  font-size: 0.8rem;
-  font-weight: 400;
+.Liberty .content-wrapper .liberty-sidebar .live-recent-wrapper .live-recent .live-recent-footer .label {
+	padding: 0.4rem;
+	font-size: 0.8rem;
+	font-weight: 400;
 }
 
-.Liberty
-  .content-wrapper
-  .liberty-sidebar
-  .live-recent-wrapper
-  .live-recent
-  .live-recent-footer
-  .label:hover {
-  transition: 0.3s;
+.Liberty .content-wrapper .liberty-sidebar .live-recent-wrapper .live-recent .live-recent-footer .label:hover {
+	transition: 0.3s;
 }
 
 .Liberty .content-wrapper .liberty-sidebar .right-ads {
-  position: absolute;
-  top: 25.73rem;
-  width: 15rem;
+	position: absolute;
+	top: 25.73rem;
+	width: 15rem;
 }
 /* Right menu End */
 
 /* Content */
 .Liberty .content-wrapper {
-  margin-top: 3.33rem;
-  z-index: -1;
+	margin-top: 3.33rem;
+	z-index: -1;
 }
 
 .Liberty .content-wrapper .liberty-content {
-  margin-right: 16rem;
-  padding: 0;
-  padding-bottom: 1rem;
+	margin-right: 16rem;
+	padding: 0;
+	padding-bottom: 1rem;
 }
 
 .Liberty .content-wrapper .liberty-content .liberty-content-header {
-  border: 1px solid #e1e8ed;
-  border-radius: 0.35rem 0.35rem 0 0;
-  background-color: #f5f8fa;
+	border: 1px solid #e1e8ed;
+	border-radius: 0.35rem 0.35rem 0 0;
+	background-color: #f5f8fa;
 }
 
-.Liberty
-  .content-wrapper
-  .liberty-content
-  .liberty-content-header
-  .liberty-notice {
-  margin: 1rem;
+.Liberty .content-wrapper .liberty-content .liberty-content-header .liberty-notice {
+	margin: 1rem;
 }
 
-.Liberty
-  .content-wrapper
-  .liberty-content
-  .liberty-content-header
-  .liberty-notice
-  ul {
-  list-style-image: none;
-  list-style-type: none;
-  text-align: center;
-  line-height: 1.8rem;
+.Liberty .content-wrapper .liberty-content .liberty-content-header .liberty-notice ul {
+	list-style-image: none;
+	list-style-type: none;
+	text-align: center;
+	line-height: 1.8rem;
 }
 
-.Liberty
-  .content-wrapper
-  .liberty-content
-  .liberty-content-header
-  .content-tools {
-  float: right;
-  padding-right: 1rem;
-  padding-top: 1rem;
+.Liberty .content-wrapper .liberty-content .liberty-content-header .content-tools {
+	float: right;
+	padding-right: 1rem;
+	padding-top: 1rem;
 }
 
-.Liberty
-  .content-wrapper
-  .liberty-content
-  .liberty-content-header
-  .content-tools
-  .tools-btn {
-  font-size: 0.9rem;
-  padding: 0.4rem 0.8rem;
+.Liberty .content-wrapper .liberty-content .liberty-content-header .content-tools .tools-btn {
+	font-size: 0.9rem;
+	padding: 0.4rem 0.8rem;
 }
 
-.Liberty
-  .content-wrapper
-  .liberty-content
-  .liberty-content-header
-  .content-tools
-  .dropdown-toggle {
-  padding: 0.4rem 0.3rem;
+.Liberty .content-wrapper .liberty-content .liberty-content-header .content-tools .dropdown-toggle {
+	padding: 0.4rem 0.3rem;
 }
 
-.Liberty
-  .content-wrapper
-  .liberty-content
-  .liberty-content-header
-  .content-tools
-  .tools-btn:hover,
-.Liberty
-  .content-wrapper
-  .liberty-content
-  .liberty-content-header
-  .content-tools
-  .tools-btn:focus,
-.Liberty
-  .content-wrapper
-  .liberty-content
-  .liberty-content-header
-  .content-tools
-  .tools-btn:active {
-  color: #fff;
-  transition: 0.3s;
-  outline: 0;
-  border-color: #e1e8ed;
+.Liberty .content-wrapper .liberty-content .liberty-content-header .content-tools .tools-btn:hover,
+.Liberty .content-wrapper .liberty-content .liberty-content-header .content-tools .tools-btn:focus,
+.Liberty .content-wrapper .liberty-content .liberty-content-header .content-tools .tools-btn:active {
+	color: #fff;
+	transition: 0.3s;
+	outline: 0;
+	border-color: #e1e8ed;
 }
 
-.Liberty
-  .content-wrapper
-  .liberty-content
-  .liberty-content-header
-  .content-tools
-  .dropdown-menu {
-  top: 92%;
+.Liberty .content-wrapper .liberty-content .liberty-content-header .content-tools .dropdown-menu {
+	top: 92%;
 }
 
 .Liberty .content-wrapper .liberty-content .liberty-content-header .title {
-  padding: 1rem;
+	padding: 1rem;
 }
 
 .Liberty .content-wrapper .liberty-content .liberty-content-header .contentSub {
-  margin-top: -0.5rem;
-  padding: 1rem;
-  padding-top: 0;
+	margin-top: -0.5rem;
+	padding: 1rem;
+	padding-top: 0;
 }
 
 .Liberty .content-wrapper .liberty-content .liberty-content-header .title > h1 {
-  color: #000;
-  font-weight: bold;
+	color: #000;
+	font-weight: bold;
 }
 
 .Liberty .content-wrapper .liberty-content .liberty-content-header .header-ads {
-  margin: 1rem;
-  margin-bottom: 0;
+	margin: 1rem;
+	margin-bottom: 0;
 }
 
 .Liberty .content-wrapper .liberty-content .liberty-content-main {
-  border-left: 1px solid #e1e8ed;
-  border-right: 1px solid #e1e8ed;
-  background-color: #fff;
-  padding: 1rem;
-  overflow: hidden;
-  line-height: 1.6rem;
+	border-left: 1px solid #e1e8ed;
+	border-right: 1px solid #e1e8ed;
+	background-color: #fff;
+	padding: 1rem;
+	overflow: hidden;
+	line-height: 1.6rem;
 }
 /* Content End */
 
 /* Footer */
 .Liberty .content-wrapper .liberty-footer {
-  border: 1px solid #e1e8ed;
-  border-radius: 0 0 0.35rem 0.35rem;
-  background-color: #f5f8fa;
-  padding: 1rem;
+	border: 1px solid #e1e8ed;
+	border-radius: 0 0 0.35rem 0.35rem;
+	background-color: #f5f8fa;
+	padding: 1rem;
 }
 
 .Liberty .content-wrapper .liberty-footer ul {
-  list-style-type: none;
-  list-style-image: none;
+	list-style-type: none;
+	list-style-image: none;
 }
 
 .Liberty .content-wrapper .liberty-footer ul {
-  margin-bottom: 0.8rem;
-  display: inline-block;
-  width: 100%;
+	margin-bottom: 0.8rem;
+	display: inline-block;
+	width: 100%;
 }
 
 .Liberty .content-wrapper .liberty-footer .footer-places li {
-  text-align: left;
-  float: left;
-  margin-right: 0.8rem;
+	text-align: left;
+	float: left;
+	margin-right: 0.8rem;
 }
 
 .Liberty .content-wrapper .liberty-footer .footer-icons {
-  margin-bottom: 0;
+	margin-bottom: 0;
 }
 
 .Liberty .content-wrapper .liberty-footer .footer-icons li {
-  margin-right: 0.8rem;
-  float: left;
+	margin-right: 0.8rem;
+	float: left;
 }
 /* Footer End */
 
-/* Login model */
+/* Login modal */
 .Liberty .login-modal .modal-sm {
-  width: 25rem;
+	width: 25rem;
 }
 
 .Liberty .login-modal .modal-header {
-  padding: 0.7rem;
+	padding: 0.7rem;
 }
 
 .Liberty .login-modal .modal-title {
-  text-align: center;
-  padding-left: 1.5rem;
+	text-align: center;
+	padding-left: 1.5rem;
 }
 
 .Liberty .login-modal .alert {
-  padding: 0.8rem;
-  margin-bottom: 0.8rem;
+	padding: 0.8rem;
+	margin-bottom: 0.8rem;
 }
 
 .Liberty .login-modal .alert-hidden {
-  display: none;
+	display: none;
 }
 
 .Liberty .login-modal .form-control {
-  margin-bottom: 0.8rem;
+	margin-bottom: 0.8rem;
 }
 
 .Liberty .login-modal .modal-checkbox:not(#noop) {
-  position: relative;
-  display: table;
+	position: relative;
+	display: table;
 }
 
 .Liberty .login-modal .modal-checkbox {
-  vertical-align: middle;
-  margin-bottom: 0.7rem;
+	vertical-align: middle;
+	margin-bottom: 0.7rem;
 }
 
 .Liberty .login-modal .modal-checkbox:not(#noop) input[type="checkbox"] {
-  opacity: 0;
-  width: 2em;
-  height: 2em;
-  max-width: none;
-  margin: 0;
-  display: table-cell;
+	opacity: 0;
+	width: 2em;
+	height: 2em;
+	max-width: none;
+	margin: 0;
+	display: table-cell;
 }
 
 .Liberty .login-modal .modal-checkbox:not(#noop) * {
-  vertical-align: middle;
-  font: inherit;
+	vertical-align: middle;
+	font: inherit;
 }
 
-.Liberty
-  .login-modal
-  .modal-checkbox:not(#noop)
-  input[type="checkbox"]
-  + label {
-  padding-left: 0.4em;
-  display: table-cell;
+.Liberty .login-modal .modal-checkbox:not(#noop) input[type="checkbox"] + label {
+	padding-left: 0.4em;
+	display: table-cell;
 }
 
-.Liberty
-  .login-modal
-  .modal-checkbox:not(#noop)
-  input[type="checkbox"]
-  + label::before {
-  -webkit-transition: 0.2s cubic-bezier(0.175, 0.885, 0.32, 1.275);
-  -moz-transition: 0.2s cubic-bezier(0.175, 0.885, 0.32, 1.275);
-  -o-transition: 0.2s cubic-bezier(0.175, 0.885, 0.32, 1.275);
-  transition: 0.2s cubic-bezier(0.175, 0.885, 0.32, 1.275);
-  content: "";
-  cursor: pointer;
-  -webkit-box-sizing: border-box;
-  -moz-box-sizing: border-box;
-  box-sizing: border-box;
-  position: absolute;
-  left: 0;
-  border-radius: 2px;
-  width: 2em;
-  height: 2em;
-  line-height: 2em;
-  border: 1px solid #777;
-  top: 50%;
-  margin-top: -1em;
+.Liberty .login-modal .modal-checkbox:not(#noop) input[type="checkbox"] + label::before {
+	-webkit-transition: 0.2s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+	-moz-transition: 0.2s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+	-o-transition: 0.2s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+	transition: 0.2s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+	content: "";
+	cursor: pointer;
+	-webkit-box-sizing: border-box;
+	-moz-box-sizing: border-box;
+	box-sizing: border-box;
+	position: absolute;
+	left: 0;
+	border-radius: 2px;
+	width: 2em;
+	height: 2em;
+	line-height: 2em;
+	border: 1px solid #777;
+	top: 50%;
+	margin-top: -1em;
 }
 
-.Liberty
-  .login-modal
-  .modal-checkbox:not(#noop)
-  input[type="checkbox"]
-  + label:hover::before {
-  border: 3px solid #777;
+.Liberty .login-modal .modal-checkbox:not(#noop) input[type="checkbox"] + label:hover::before {
+	border: 3px solid #777;
 }
 
-.Liberty
-  .login-modal
-  .modal-checkbox:not(#noop)
-  input[type="checkbox"]:checked
-  + label::before {
-  border: 3px solid #777;
-  background-image: linear-gradient(transparent, transparent),
-    url(data:image/svg+xml,%3C%3Fxml%20version%3D%221.0%22%20encoding%3D%22UTF-8%22%3F%3E%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2224%22%20height%3D%2224%22%3E%3Cpath%20d%3D%22M4%2012l5%205L20%205%22%20stroke%3D%22%2300B78C%22%20stroke-width%3D%223%22%20fill%3D%22none%22%2F%3E%3C%2Fsvg%3E%0A);
+.Liberty .login-modal .modal-checkbox:not(#noop) input[type="checkbox"]:checked + label::before {
+	border: 3px solid #777;
+	background-image: linear-gradient(transparent, transparent),
+		url(data:image/svg+xml,%3C%3Fxml%20version%3D%221.0%22%20encoding%3D%22UTF-8%22%3F%3E%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2224%22%20height%3D%2224%22%3E%3Cpath%20d%3D%22M4%2012l5%205L20%205%22%20stroke%3D%22%2300B78C%22%20stroke-width%3D%223%22%20fill%3D%22none%22%2F%3E%3C%2Fsvg%3E%0A);
 }
 
 .Liberty .login-modal .btn {
-  margin-bottom: 0.8rem;
+	margin-bottom: 0.8rem;
 }
 
 .Liberty .login-modal .modal-footer {
-  display: none;
+	display: none;
 }
-/* Login model End */
+/* Login modal End */
 
 /* scroll button */
 #liberty-bottombtn {
-  position: fixed;
-  width: 80px;
-  right: 0px;
-  bottom: 0px;
-  background: #4188f1;
-  height: 40px;
-  overflow: hidden;
-  padding: 0;
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  border-radius: 5px 5px 0 0;
+	position: fixed;
+	width: 80px;
+	right: 0px;
+	bottom: 0px;
+	background: #4188f1;
+	height: 40px;
+	overflow: hidden;
+	padding: 0;
+	display: grid;
+	grid-template-columns: 1fr 1fr;
+	border-radius: 5px 5px 0 0;
 }
 
 #liberty-bottombtn .scroll-button {
-  font-size: 40px;
-  line-height: 40px;
-  color: white;
-  text-align: center;
-  cursor: pointer;
+	font-size: 40px;
+	line-height: 40px;
+	color: white;
+	text-align: center;
+	cursor: pointer;
 }
 
 #liberty-bottombtn .scroll-button:hover {
-  background-color:#2774DC;
-  transition: 500ms;
+	background-color:#2774DC;
+	transition: 500ms;
 }
 
 #liberty-bottombtn #liberty-scrollup {
-  border-right: 1px solid white;
+	border-right: 1px solid white;
 }
 /* scroll button end */
 
 /* Bootstrap Custom */
 .dropdown-menu {
-  font-size: 0.95rem;
-  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175);
-  border-color: #e1e8ed;
+	font-size: 0.95rem;
+	box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175);
+	border-color: #e1e8ed;
 }
 
 .dropdown-menu .dropdown-item:hover {
-  color: #fff;
-  transition: 0.3s;
+	color: #fff;
+	transition: 0.3s;
 }
 
 .dropdown-divider {
-  border-color: #e1e8ed;
+	border-color: #e1e8ed;
 }
 
 .form-control {
-  font-size: 0.9rem;
+	font-size: 0.9rem;
 }
 
 .form-control:focus {
-  border-color: #66afe9;
-  outline: 0;
-  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075),
-    0 0 8px rgba(102, 175, 233, 0.6);
-  transition: 0.3s;
+	border-color: #66afe9;
+	outline: 0;
+	box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075),
+		0 0 8px rgba(102, 175, 233, 0.6);
+	transition: 0.3s;
 }
 
 .btn {
-  box-shadow: none;
-  border-radius: 0.35rem;
+	box-shadow: none;
+	border-radius: 0.35rem;
 }
 
 .btn:hover {
-  transition: 0.3s;
+	transition: 0.3s;
 }
 
 .btn:active,
 .btn:focus {
-  outline: 0;
+	outline: 0;
 }
 
 .input-group-btn:last-child > .btn,
 .input-group-btn:last-child > .btn-group {
-  z-index: 3; /* Firefox, IE border bug fix */
+	z-index: 3; /* Firefox, IE border bug fix */
 }
 
 .close:focus,
 .close:hover {
-  transition: 0.3s;
+	transition: 0.3s;
 }
 
 caption {
-  color: #373a3c;
-  caption-side: top;
+	color: #373a3c;
+	caption-side: top;
 }
 /* Bootstrap Custom End */
 
 /* AdSense */
 ins.adsbygoogle {
-  display: block;
-  width: 100%;
-  height: 90px;
+	display: block;
+	width: 100%;
+	height: 90px;
 }
 
 .header-ads > ins {
-  min-width: 20rem;
+	min-width: 20rem;
 }
 
 .right-ads > ins {
-  min-width: 15rem;
+	min-width: 15rem;
 }
 /* AdSense End */
 
 /* Echo */
 #pt-notifications-alert,
 #pt-notifications-notice {
-  position: relative;
-  float: right;
-  list-style: none;
-  top: 0.8rem;
-  font-size: 0.9rem;
-  margin-right: 0.6rem;
-  margin-left: 0.8rem;
+	position: relative;
+	float: right;
+	list-style: none;
+	top: 0.8rem;
+	font-size: 0.9rem;
+	margin-right: 0.6rem;
+	margin-left: 0.8rem;
 }
 /* Echo End */
 
 #shareAPIPolyfill-container button {
-  color: inherit;
-  white-space: inherit;
-  line-height: inherit;
+	color: inherit;
+	white-space: inherit;
+	line-height: inherit;
 }

--- a/css/only-mw.css
+++ b/css/only-mw.css
@@ -1,73 +1,56 @@
 /* ToC */
 .Liberty .content-wrapper .liberty-content .liberty-content-main .toc {
-    border-bottom-right-radius: 0.35rem;
-    border-bottom-left-radius: 0.35rem;
-    display: inline-block;
-    font-size: 0.9rem;
+	border-bottom-right-radius: 0.35rem;
+	border-bottom-left-radius: 0.35rem;
+	display: inline-block;
+	font-size: 0.9rem;
 }
 
-.Liberty
-    .content-wrapper
-    .liberty-content
-    .liberty-content-main
-    .toc
-    .toctitle {
-    background-color: #f5f8fa;
-    border: 1px solid #e1e8ed;
-    border-top-right-radius: 0.35rem;
-    border-top-left-radius: 0.35rem;
-    padding: 0.6rem 1.2rem;
+.Liberty .content-wrapper .liberty-content .liberty-content-main .toc .toctitle {
+	background-color: #f5f8fa;
+	border: 1px solid #e1e8ed;
+	border-top-right-radius: 0.35rem;
+	border-top-left-radius: 0.35rem;
+	padding: 0.6rem 1.2rem;
 }
 
-.Liberty
-    .content-wrapper
-    .liberty-content
-    .liberty-content-main
-    .toc
-    .toctitle
-    h2 {
-    display: inline;
-    font-size: 1.2rem;
-    font-weight: bold;
-    border: none;
+.Liberty .content-wrapper .liberty-content .liberty-content-main .toc .toctitle h2 {
+	display: inline;
+	font-size: 1.2rem;
+	font-weight: bold;
+	border: none;
 }
 
 .Liberty .content-wrapper .liberty-content .liberty-content-main .toc ul,
 .Liberty .content-wrapper .liberty-content .liberty-content-main .toc li {
-    background-color: #fff;
-    list-style-type: none;
-    list-style-image: none;
+	background-color: #fff;
+	list-style-type: none;
+	list-style-image: none;
 }
 
 .Liberty .content-wrapper .liberty-content .liberty-content-main .toc > ul {
-    margin: 0;
-    padding: 0.6rem 1.2rem;
-    border: 1px solid #e1e8ed;
-    border-top: none;
-    border-bottom-right-radius: 0.35rem;
-    border-bottom-left-radius: 0.35rem;
+	margin: 0;
+	padding: 0.6rem 1.2rem;
+	border: 1px solid #e1e8ed;
+	border-top: none;
+	border-bottom-right-radius: 0.35rem;
+	border-bottom-left-radius: 0.35rem;
 }
 
 .Liberty .content-wrapper .liberty-content .liberty-content-main .toc ul ul {
-    margin: 0 0 0 1rem !important;
+	margin: 0 0 0 1rem !important;
 }
 
 .Liberty .content-wrapper .liberty-content .liberty-content-main .toc .toctext {
-    color: #373a3c;
+	color: #373a3c;
 }
 
 .Liberty .content-wrapper .liberty-content .liberty-content-main .toc a:hover {
-    text-decoration: none;
+	text-decoration: none;
 }
 
-.Liberty
-    .content-wrapper
-    .liberty-content
-    .liberty-content-main
-    .toc
-    a
-    > .tocnumber:hover {
-    text-decoration: underline;
+.Liberty .content-wrapper .liberty-content .liberty-content-main .toc a > .tocnumber:hover {
+	text-decoration: underline;
 }
 /* ToC End */
 
@@ -78,196 +61,167 @@
 .Liberty .content-wrapper .liberty-content .liberty-content-main h4,
 .Liberty .content-wrapper .liberty-content .liberty-content-main h5,
 .Liberty .content-wrapper .liberty-content .liberty-content-main h6 {
-    margin-top: 1rem;
-    border-bottom: 1px dashed #e1e8ed;
-    margin-bottom: 0.6rem;
-    padding-bottom: 0.6rem;
-    overflow-wrap: break-word;
-    overflow: hidden;
+	margin-top: 1rem;
+	border-bottom: 1px dashed #e1e8ed;
+	margin-bottom: 0.6rem;
+	padding-bottom: 0.6rem;
+	overflow-wrap: break-word;
+	overflow: hidden;
 }
 
-.Liberty
-    .content-wrapper
-    .liberty-content
-    .liberty-content-main
-    .mw-headline-number {
-    color: #4188f1;
+.Liberty .content-wrapper .liberty-content .liberty-content-main .mw-headline-number {
+	color: #4188f1;
 }
 /* Title End */
 
 /* Content */
 .Liberty .content-wrapper .liberty-content .liberty-content-main ul {
-    margin: 0.5rem 0 0.5rem 1.6rem;
+	margin: 0.5rem 0 0.5rem 1.6rem;
 }
 
 .Liberty .content-wrapper .liberty-content .liberty-content-main .toccolours {
-    background-color: #f5f8fa;
-    border-color: #e1e8ed;
-    border-radius: 0.35rem;
+	background-color: #f5f8fa;
+	border-color: #e1e8ed;
+	border-radius: 0.35rem;
 }
 
 .Liberty .content-wrapper .liberty-content .liberty-content-main .catlinks {
-    border: 1px solid #e1e8ed;
-    padding: 0.4rem;
-    padding-left: 1rem;
-    box-shadow: 0.15rem 0.15rem 0 0 #cfdae2;
-    margin-bottom: 0.8rem;
-    border-radius: 0.35rem;
-    display: inline-block;
-    width: 100%;
+	border: 1px solid #e1e8ed;
+	padding: 0.4rem;
+	padding-left: 1rem;
+	box-shadow: 0.15rem 0.15rem 0 0 #cfdae2;
+	margin-bottom: 0.8rem;
+	border-radius: 0.35rem;
+	display: inline-block;
+	width: 100%;
 }
 
 .Liberty
-    .content-wrapper
-    .liberty-content
-    .liberty-content-main
-    .catlinks-allhidden {
-    display: none;
+	.content-wrapper
+	.liberty-content
+	.liberty-content-main
+	.catlinks-allhidden {
+	display: none;
 }
 
 .Liberty .content-wrapper .liberty-content .liberty-content-main .catlinks ul {
-    padding: 0;
-    margin-left: 0.5rem;
+	padding: 0;
+	margin-left: 0.5rem;
 }
 
-.Liberty
-    .content-wrapper
-    .liberty-content
-    .liberty-content-main
-    .catlinks
-    ul
-    > li {
-    margin: 0;
+.Liberty .content-wrapper .liberty-content .liberty-content-main .catlinks ul > li {
+	margin: 0;
 }
 /* Content */
 
 /* Special Pages */
-.Liberty
-    .content-wrapper
-    .liberty-content
-    .liberty-content-main
-    .mw-specialpages-table {
-    margin-top: 0;
+.Liberty .content-wrapper .liberty-content .liberty-content-main .mw-specialpages-table {
+	margin-top: 0;
 }
 
 .Liberty .content-wrapper .liberty-content .liberty-content-main fieldset {
-    border: 1px solid #e1e8ed;
-    padding: 1rem;
-    padding-top: 0;
+	border: 1px solid #e1e8ed;
+	padding: 1rem;
+	padding-top: 0;
 }
 
 .Liberty .content-wrapper .liberty-content .liberty-content-main legend {
-    padding: 0.5rem;
-    font-size: 0.9rem;
-    width: auto;
-    margin: 0;
+	padding: 0.5rem;
+	font-size: 0.9rem;
+	width: auto;
+	margin: 0;
 }
 /* Special Pages End */
 
 /* Search results */
 html .suggestions-results {
-    border-color: #e1e8ed;
-    padding: 0.5rem;
+	border-color: #e1e8ed;
+	padding: 0.5rem;
 }
 
 html .suggestions-special {
-    border-color: #e1e8ed;
-    padding: 0.5rem;
-    border-bottom-right-radius: 0.35rem;
-    border-bottom-left-radius: 0.35rem;
-    background-color: #f5f8fa;
+	border-color: #e1e8ed;
+	padding: 0.5rem;
+	border-bottom-right-radius: 0.35rem;
+	border-bottom-left-radius: 0.35rem;
+	background-color: #f5f8fa;
 }
 
 html .suggestions-result-current {
-    background-color: #4c59a6;
-    color: #373a3c;
-    transition: 0.3s;
+	background-color: #4c59a6;
+	color: #373a3c;
+	transition: 0.3s;
 }
 /* Search results End */
 
 /* Thumbnail */
 .Liberty .content-wrapper .liberty-content .liberty-content-main .center {
-    margin: auto;
-    text-align: center;
+	margin: auto;
+	text-align: center;
 }
 
 .Liberty .content-wrapper .liberty-content .liberty-content-main .thumbinner {
-    margin: auto;
+	margin: auto;
 }
 /* Thumbnail End */
 
 /* Recent Changes (Menu) */
-.Liberty
-    .content-wrapper
-    .liberty-content
-    .liberty-content-main
-    .mw-changeslist
-    > h4 {
-    margin-bottom: 0.2rem;
+.Liberty .content-wrapper .liberty-content .liberty-content-main .mw-changeslist > h4 {
+	margin-bottom: 0.2rem;
 }
 .Liberty .content-wrapper .liberty-content .liberty-content-main .special {
-    margin: 0;
-    padding: 0;
-    list-style-image: none;
-    list-style-type: none;
+	margin: 0;
+	padding: 0;
+	list-style-image: none;
+	list-style-type: none;
 }
 
-.Liberty
-    .content-wrapper
-    .liberty-content
-    .liberty-content-main
-    .special
-    .mw-changeslist-separator {
-    display: none;
+.Liberty .content-wrapper .liberty-content .liberty-content-main .special .mw-changeslist-separator {
+	display: none;
 }
 
 .Liberty .content-wrapper .liberty-content .liberty-content-main .special > li {
-    border-bottom: 1px solid #e1e8ed;
-    padding: 0.5rem 0;
+	border-bottom: 1px solid #e1e8ed;
+	padding: 0.5rem 0;
 }
 /* Recent Changes (Menu) End */
 
 /* Image */
 .Liberty .content-wrapper .liberty-content .liberty-content-main .tright {
-    margin-left: 0.8rem;
-    margin-bottom: 0.8rem;
+	margin-left: 0.8rem;
+	margin-bottom: 0.8rem;
 }
 
-.Liberty
-    .content-wrapper
-    .liberty-content
-    .liberty-content-main
-    .thumb
-    .thumbcaption {
-    padding-top: 0.4rem;
-    text-align: center;
+.Liberty .content-wrapper .liberty-content .liberty-content-main .thumb .thumbcaption {
+	padding-top: 0.4rem;
+	text-align: center;
 }
 
 .Liberty .content-wrapper .liberty-content .liberty-content-main .thumb img {
-    box-shadow: 0.25rem 0.25rem 0 0 #e1e8ed;
+	box-shadow: 0.25rem 0.25rem 0 0 #e1e8ed;
 }
 /* Image End */
 
 /* Left ToC */
 #fixed-toc ul {
-    list-style-image: none;
-    list-style-type: none;
+	list-style-image: none;
+	list-style-type: none;
 }
 
 #fixed-toc .toctext {
-    color: #373a3c;
+	color: #373a3c;
 }
 
 #fixed-toc .toctitle h2 {
-    display: inline-block;
+	display: inline-block;
 }
 
 #fixed-toc .toctitle .toctoggle {
-    display: inline-block;
+	display: inline-block;
 }
 
 #fixed-toc ul ul {
-    margin-left: 1rem;
+	margin-left: 1rem;
 }
 /* Left ToC End */
 
@@ -275,107 +229,100 @@ html .suggestions-result-current {
 /* The OOUI selector is a horrible hack for the new Recent Changes Filters in MW 1.32+ */
 select,
 input:not([type="button"]):not([type="checkbox"]):not([type="submit"]):not([class="oo-ui-inputWidget-input"]) {
-    display: inline-block;
-    padding: 0.2rem 0.4rem;
-    font-size: 1rem;
-    line-height: 1.5;
-    color: #55595c;
-    background-color: #fff;
-    background-image: none;
-    border: 1px solid #ccc;
-    border-radius: 0.25rem;
+	display: inline-block;
+	padding: 0.2rem 0.4rem;
+	font-size: 1rem;
+	line-height: 1.5;
+	color: #55595c;
+	background-color: #fff;
+	background-image: none;
+	border: 1px solid #ccc;
+	border-radius: 0.25rem;
 }
 
 html input.oo-ui-inputWidget-input[type="search"] {
-    padding-left: 2.5em !important;
+	padding-left: 2.5em !important;
 }
 
 select:focus,
 input:not([type="button"]):not([type="checkbox"]):not([type="submit"]):focus {
-    border-color: #66afe9;
-    outline: 0;
+	border-color: #66afe9;
+	outline: 0;
 }
 
 input[type="button"],
 input[type="submit"],
 button {
-    box-shadow: none;
-    display: inline-block;
-    padding: 0.2rem 1rem;
-    font-size: 1rem;
-    font-weight: 400;
-    line-height: 1.5;
-    text-align: center;
-    white-space: nowrap;
-    cursor: pointer;
-    border: 1px solid transparent;
-    border-radius: 0.25rem;
-    /* btn-success */
-    color: #fff;
-    background-color: #5cb85c;
+	box-shadow: none;
+	display: inline-block;
+	padding: 0.2rem 1rem;
+	font-size: 1rem;
+	font-weight: 400;
+	line-height: 1.5;
+	text-align: center;
+	white-space: nowrap;
+	cursor: pointer;
+	border: 1px solid transparent;
+	border-radius: 0.25rem;
+	/* btn-success */
+	color: #fff;
+	background-color: #5cb85c;
 }
 
 input[type="button"]:hover,
 input[type="submit"]:hover,
 button:hover {
-    background-color: #449d44;
+	background-color: #449d44;
 }
 
 #wpDestFile {
-    width: 100%;
+	width: 100%;
 }
 
 td.mw-label {
-    width: 15%;
-    padding-right: 10px;
+	width: 15%;
+	padding-right: 10px;
 }
 
 #mw-upload-form > .mw-htmlform-submit-buttons > .mw-htmlform-submit {
-    margin-top: 20px;
+	margin-top: 20px;
 }
 
-/* Fix for visualeditor */
+/* Fix for VisualEditor */
 .action-edit .content-wrapper .liberty-content .liberty-content-main {
-    overflow: visible hidden;
+	overflow: visible hidden;
 }
 
 .mw-body-content + .ve-ui-surface {
-    padding: 0.5rem;
-    min-height: 40em;
-    max-height: calc(100vh - 22rem);
-    overflow-y: scroll;
+	padding: 0.5rem;
+	min-height: 40em;
+	max-height: calc(100vh - 22rem);
+	overflow-y: scroll;
 }
 
-.liberty-content-main
-    > .ve-init-target
-    .oo-ui-toolbar-popups
-    > .oo-ui-popupToolGroup-active-tools {
-    overflow-x: visible;
+.liberty-content-main > .ve-init-target .oo-ui-toolbar-popups > .oo-ui-popupToolGroup-active-tools {
+	overflow-x: visible;
 }
 
-.liberty-content-main
-    > .ve-init-target
-    .oo-ui-toolbar-popups
-    > .oo-ui-popupTool-popup
-    > .oo-ui-popupWidget-popup {
-    max-width: calc(100vw - 1rem);
+.liberty-content-main > .ve-init-target .oo-ui-toolbar-popups > .oo-ui-popupTool-popup > .oo-ui-popupWidget-popup {
+	max-width: calc(100vw - 1rem);
 }
 
 /* Input End */
 
 /* PostEdit */
 html .postedit-container {
-    z-index: 3000;
+	z-index: 3000;
 }
 
 /* Fieldset overflow */
 fieldset {
-    overflow-x: scroll;
+	overflow-x: scroll;
 }
 
 /* Hide empty list elements (T192446) */
 .mw-empty-elt {
-    display: none;
+	display: none;
 }
 
 /**
@@ -384,25 +331,25 @@ fieldset {
  * Styles copied from /resources/src/mediawiki.skinning/interface.css@REL1_34
  */
 .usermessage {
-    background-color: #ffce7b;
-    border: 1px solid #ffa500;
-    color: #000;
-    font-weight: bold;
-    margin: 2em 0 1em;
-    padding: 0.5em 1em;
-    vertical-align: middle;
+	background-color: #ffce7b;
+	border: 1px solid #ffa500;
+	color: #000;
+	font-weight: bold;
+	margin: 2em 0 1em;
+	padding: 0.5em 1em;
+	vertical-align: middle;
 }
 
 /* Preferences */
 #mw-prefsection-liberty {
-    padding-top: 1rem;
+	padding-top: 1rem;
 }
 
 /* Extensions */
 
 /* MsUpload */
 html #msupload-dropzone {
-    height: auto;
+	height: auto;
 }
 /* MsUpload End */
 

--- a/js/ads.js
+++ b/js/ads.js
@@ -1,15 +1,15 @@
-$(function () {
-    "use strict";
+$( function () {
+    'use strict';
     var width, rightAds;
-    if ($(".mobile-ads") !== undefined) {
-        width = $(window).width();
-        if (width < 1024) {
-            rightAds = $(".right-ads").html();
-            $(".mobile-ads").html(rightAds);
-            $(".right-ads").remove();
+    if ( $( '.mobile-ads' ) !== undefined ) {
+        width = $( window ).width();
+        if ( width < 1024 ) {
+            rightAds = $( '.right-ads' ).html();
+            $( '.mobile-ads' ).html( rightAds );
+            $( '.right-ads' ).remove();
         }
     }
-    $(".adsbygoogle").each(function () {
-        (window.adsbygoogle = window.adsbygoogle || []).push({});
-    });
-});
+    $( '.adsbygoogle' ).each( function () {
+        ( window.adsbygoogle = window.adsbygoogle || [] ).push( {} );
+    } );
+} );

--- a/js/delay-scrolling.js
+++ b/js/delay-scrolling.js
@@ -1,96 +1,97 @@
-$(window).on('load',function () {
+$( window ).on( 'load', function () {
 	'use strict';
 	var hash, navHeight, id;
+
 	/* Anchor Process */
 	hash = window.location.hash;
-	navHeight = $('.nav-wrapper').height();
+	navHeight = $( '.nav-wrapper' ).height();
 
-	if (hash.indexOf('.') !== -1) {
-		hash = String(hash);
-		hash = document.getElementById(hash.replace('#', ''));
+	if ( hash.indexOf( '.' ) !== -1 ) {
+		hash = String( hash );
+		hash = document.getElementById( hash.replace( '#', '' ) );
 	}
 
-	if (hash) {
-		$('html, body').animate({ scrollTop: $(hash).offset().top - navHeight - 10 }, 350);
+	if ( hash ) {
+		$( 'html, body' ).animate( { scrollTop: $( hash ).offset().top - navHeight - 10 }, 350 );
 	}
 	/* Anchor Process End */
 
-	/* Toc click process */
-	$('.toc ul li > a').click(function () {
-		if ($(this).attr('href')[0] === '#') {
-			id = String($(this).attr('href'));
-			if (id.indexOf('.') !== -1) {
-				id = document.getElementById(id.replace('#', ''));
+	/* ToC click process */
+	$( '.toc ul li > a' ).click( function () {
+		if ( $( this ).attr( 'href' )[ 0 ] === '#' ) {
+			id = String( $( this ).attr( 'href' ) );
+			if ( id.indexOf( '.' ) !== -1 ) {
+				id = document.getElementById( id.replace( '#', '' ) );
 			}
-			$('html,body').animate({
-				scrollTop: ($(id).offset().top - navHeight - 10)
-			}, 350);
+			$( 'html,body' ).animate( {
+				scrollTop: ( $( id ).offset().top - navHeight - 10 )
+			}, 350 );
 			return false;
 		}
-	});
-	/* Toc click process End */
+	} );
+	/* ToC click process End */
 
 	/* Title number click process */
-	$('.mw-headline-number').click(function () {
-		$('html,body').animate({
-			scrollTop: ($('#toctitle').offset().top - navHeight - 10)
-		}, 350);
+	$( '.mw-headline-number' ).click( function () {
+		$( 'html,body' ).animate( {
+			scrollTop: ( $( '#toctitle' ).offset().top - navHeight - 10 )
+		}, 350 );
 		return false;
-	});
+	} );
 	/* Title number click process End */
 
-	/* Toc Click Process */
-	$('.mw-cite-backlink > a').click(function () {
-		if ($(this).attr('href')[0] === '#') {
-			id = String($(this).attr('href'));
-			if (id.indexOf('.') !== -1) {
-				id = document.getElementById(id.replace('#', ''));
+	/* ToC Click Process */
+	$( '.mw-cite-backlink > a').click( function () {
+		if ( $( this ).attr( 'href' )[ 0 ] === '#' ) {
+			id = String( $( this ).attr( 'href' ) );
+			if ( id.indexOf( '.' ) !== -1 ) {
+				id = document.getElementById( id.replace( '#', '' ) );
 			}
-			$('html,body').animate({
-				scrollTop: ($(id).offset().top - navHeight - 10)
-			}, 400);
+			$( 'html,body' ).animate( {
+				scrollTop: ( $( id ).offset().top - navHeight - 10 )
+			}, 400 );
 			return false;
 		}
-	});
+	} );
 
-	$('.mw-cite-backlink > * > a').click(function () {
-		if ($(this).attr('href')[0] === '#') {
-			id = String($(this).attr('href'));
-			if (id.indexOf('.') !== -1) {
-				id = document.getElementById(id.replace('#', ''));
+	$( '.mw-cite-backlink > * > a' ).click( function () {
+		if ( $( this ).attr( 'href' )[ 0 ] === '#' ) {
+			id = String( $( this ).attr( 'href' ) );
+			if ( id.indexOf( '.' ) !== -1 ) {
+				id = document.getElementById( id.replace( '#', '' ) );
 			}
-			$('html,body').animate({
-				scrollTop: ($(id).offset().top - navHeight - 10)
-			}, 400);
+			$( 'html,body' ).animate( {
+				scrollTop: ( $( id ).offset().top - navHeight - 10 )
+			}, 400 );
 			return false;
 		}
-	});
+	} );
 
-	$('.reference > a').click(function () {
-		if ($(this).attr('href')[0] === '#') {
-			id = String($(this).attr('href'));
-			if (id.indexOf('.') !== -1) {
-				id = document.getElementById(id.replace('#', ''));
+	$( '.reference > a' ).click( function () {
+		if ( $( this ).attr( 'href' )[ 0 ] === '#' ) {
+			id = String( $( this ).attr( 'href' ) );
+			if ( id.indexOf( '.' ) !== -1 ) {
+				id = document.getElementById( id.replace( '#', '' ) );
 			}
-			$('html,body').animate({
-				scrollTop: ($(id).offset().top - navHeight - 10)
+			$( 'html,body' ).animate( {
+				scrollTop: ( $( id ).offset().top - navHeight - 10 )
 			}, 400);
 			return false;
 		}
-	});
-	/* Toc Click Process End */
+	} );
+	/* ToC Click Process End */
 
 	/* Preference Tab Click Process */
-	$('#preftoc li > a').click(function () {
-		if ($(this).attr('href')[0] === '#') {
-			id = String($(this).attr('href'));
-			if (id.indexOf('.') !== -1) {
-				id = document.getElementById(id.replace('#', ''));
+	$( '#preftoc li > a' ).click( function () {
+		if ( $( this ).attr( 'href' )[ 0 ] === '#' ) {
+			id = String( $( this ).attr( 'href' ) );
+			if ( id.indexOf( '.' ) !== -1 ) {
+				id = document.getElementById( id.replace( '#', '' ) );
 			}
-			$('html,body').animate({
-				scrollTop: (0)
+			$( 'html,body' ).animate( {
+				scrollTop: ( 0 )
 			}, 350);
 		}
-	});
+	} );
 	/* Preference Tab Click Process End */
-});
+} );

--- a/js/live-recent.js
+++ b/js/live-recent.js
@@ -1,6 +1,7 @@
 $( function () {
 	'use strict';
 	var articleNamespaces, talkNamespaces, isArticleTab, limit;
+
 	articleNamespaces = $( '.live-recent' ).attr( 'data-article-ns' );
 	talkNamespaces = $( '.live-recent' ).attr( 'data-talk-ns' );
 	isArticleTab = true;
@@ -30,9 +31,11 @@ $( function () {
 
 	function refreshLiveRecent() {
 		var getParameter;
+
 		if ( !$( '#live-recent-list' ).length || $( '#live-recent-list' ).is( ':hidden' ) ) {
 			return;
 		}
+
 		getParameter = {
 			action: 'query',
 			list: 'recentchanges',
@@ -44,7 +47,8 @@ $( function () {
 			rcnamespace: isArticleTab ? articleNamespaces : talkNamespaces,
 			rctoponly: true
 		};
-		mw.loader.using( 'mediawiki.api' ).then(function() {
+
+		mw.loader.using( 'mediawiki.api' ).then( function () {
 			var api = new mw.Api();
 			api.get( getParameter ).then( function ( data ) {
 				var recentChanges, html, time, line, text;
@@ -67,7 +71,7 @@ $( function () {
 					return line;
 				} ).join( '\n' );
 				$( '#live-recent-list' ).html( html );
-			})
+			} )
 			.catch( function () {} );
 		});
 	}

--- a/js/scroll-button.js
+++ b/js/scroll-button.js
@@ -1,10 +1,11 @@
-$(document).ready(function () {
-  $("#liberty-scrollup").click(function () {
-    $("html, body").animate({ scrollTop: 0 }, 400);
-    return false;
-  });
-  $("#liberty-scrolldown").click(function () {
-    $("html, body").animate({ scrollTop: $(document).height() }, 400);
-    return false;
-  });
-});
+$( function () {
+    $( '#liberty-scrollup' ).click( function () {
+        $( 'html, body' ).animate( { scrollTop: 0 }, 400 );
+        return false;
+    } );
+
+    $( '#liberty-scrolldown' ).click( function () {
+        $( 'html, body' ).animate( { scrollTop: $( document ).height() }, 400 );
+        return false;
+    } );
+} );

--- a/js/share-button.js
+++ b/js/share-button.js
@@ -5,18 +5,18 @@ $( '.tools-share' ).click( function () {
 	if ( host.startsWith( '//' ) ) {
 		host = location.protocol + host;
 	}
-	ns = mw.config.get('wgNamespaceNumber')
+	ns = mw.config.get( 'wgNamespaceNumber' );
 	title = mw.config.get( 'wgTitle' );
 	if ( ns ) {
-		title = mw.config.get( 'wgFormattedNamespaces' )[ns] + ':' + title;
+		title = mw.config.get( 'wgFormattedNamespaces' )[ ns ] + ':' + title;
 	}
-	url = host + mw.config.get( 'wgScriptPath' ) + '/index.php?curid=' + mw.config.get( 'wgArticleId' )
-	navigator.share({
+	url = host + mw.config.get( 'wgScriptPath' ) + '/index.php?curid=' + mw.config.get( 'wgArticleId' );
+	navigator.share( {
 		title: title,
 		text: title + ' - ' + mw.config.get( 'wgSiteName' ),
 		url: url,
 		hashtags: [ mw.config.get( 'wgSiteName' ).replace( / /g, '_' ) ]
-	})
+	} )
 	.catch( function ( error ) {
 		console.error( 'Share API error: ', error );
 	} );

--- a/skin.json
+++ b/skin.json
@@ -1,154 +1,154 @@
 {
-    "name": "Liberty",
-    "author": [
-        "Librewiki developers",
-        "..."
-    ],
-    "url": "https://gitlab.com/librewiki/Liberty-MW-Skin",
-    "descriptionmsg": "liberty-desc",
-    "namemsg": "skinname-liberty",
-    "license-name": "GPL-3.0-or-later",
-    "type": "skin",
-    "version": "1.11.0",
-    "requires": {
-        "MediaWiki": ">= 1.37.0"
-    },
-    "ValidSkinNames": {
-        "liberty": "Liberty"
-    },
-    "MessagesDirs": {
-        "Liberty": [
-            "i18n"
-        ]
-    },
-    "config": {
-        "LibertyEnableLiveRC": true,
-        "LibertyUseGravatar": true,
-        "LibertyMainColor": "#4188F1",
-        "LibertySecondColor": null,
-        "LibertyAdSetting": null,
-        "LibertyOgLogo": null,
-        "TwitterAccount": null,
-        "NaverVerification": null,
-        "wgLibertyMobileReplaceAd": false,
-        "LibertyLiveRCArticleNamespaces": [
-            0,
-            4,
-            10,
-            12,
-            14
-        ],
-        "LibertyLiveRCTalkNamespaces": [
-            1,
-            3,
-            5,
-            7,
-            9,
-            11,
-            13,
-            15
-        ],
-        "LibertyMaxRecent": 10
-    },
-    "AvailableRights": [
-        "blockads-header",
-        "blockads-right",
-        "blockads-belowarticle",
-        "blockads-bottom"
-    ],
-    "ResourceModules": {
-        "skins.liberty.styles": {
-            "class": "ResourceLoaderSkinModule",
-            "features": {
-                "legacy": false,
-                "interface": false,
-                "toc": false
-            },
-            "styles": {
-                "bootstrap/css/bootstrap.min.css": {
-                    "media": "all"
-                },
-                "css/default.css": {
-                    "media": "all"
-                },
-                "css/default_mobile.css": {
-                    "media": "all"
-                },
-                "css/wiki.css": {
-                    "media": "all"
-                },
-                "css/only-mw.css": {
-                    "media": "all"
-                },
-                "css/webfont.css": {
-                    "media": "all"
-                },
-                "css/wiki-table.css": {
-                    "media": "all"
-                },
-                "css/wikiedittor-liberty.css": {
-                    "media": "all"
-                },
-                "css/extensions/RelatedArticles.css": {
-                    "media": "all"
-                },
-                "css/print.css": {
-                    "media": "print"
-                }
-            }
-        },
-        "skins.liberty.ads": {
-            "scripts": "js/ads.js"
-        },
-        "skins.liberty.bootstrap": {
-            "scripts": [
-                "js/lib/jquery.ba-throttle-debounce.js",
-                "js/lib/bootstrap.min.js"
-            ]
-        },
-        "skins.liberty.layoutjs": {
-            "scripts": [
-                "js/delay-scrolling.js",
-                "js/disable-notice.js",
-                "js/share-button.js",
-                "js/layout.js",
-                "js/table.js",
-                "js/scroll-button.js"
-            ],
-            "dependencies": "mediawiki.cookie"
-        },
-        "skins.liberty.liverc": {
-            "scripts": "js/live-recent.js",
-            "messages": [
-                "liberty-feed-new"
-            ],
-            "dependencies": "mediawiki.util"
-        },
-        "skins.liberty.loginjs": {
-            "scripts": "js/login-request.js",
-            "dependencies": "mediawiki.util"
-        }
-    },
-    "ResourceFileModulePaths": {
-        "localBasePath": "",
-        "remoteSkinPath": "Liberty"
-    },
-    "ResourceModuleSkinStyles": {
-        "liberty": {
-            "+ext.relatedArticles.readMore": "css/extensions/RelatedArticles.css",
-            "+ext.echo.ui": "css/extensions/Echo.css",
-            "+mediawiki.action.view.filepage": "css/skinStyles/mediawiki.action.view.filepage.css",
-            "+mediawiki.special.preferences.styles": "css/skinStyles/mediawiki.special.preferences.styles.css"
-        }
-    },
-    "AutoloadClasses": {
-        "SkinLiberty": "SkinLiberty.php",
-        "LibertyTemplate": "LibertyTemplate.php",
-        "LibertyHooks": "LibertyHooks.php"
-    },
-    "Hooks": {
-        "GetPreferences": "LibertyHooks::onGetPreferences",
-        "OutputPageBodyAttributes": "LibertyHooks::onOutputPageBodyAttributes"
-    },
-    "manifest_version": 1
+	"name": "Liberty",
+	"author": [
+		"Librewiki developers",
+		"..."
+	],
+	"url": "https://gitlab.com/librewiki/Liberty-MW-Skin",
+	"descriptionmsg": "liberty-desc",
+	"namemsg": "skinname-liberty",
+	"license-name": "GPL-3.0-or-later",
+	"type": "skin",
+	"version": "1.11.0",
+	"requires": {
+		"MediaWiki": ">= 1.37.0"
+	},
+	"ValidSkinNames": {
+		"liberty": "Liberty"
+	},
+	"MessagesDirs": {
+		"Liberty": [
+			"i18n"
+		]
+	},
+	"config": {
+		"LibertyEnableLiveRC": true,
+		"LibertyUseGravatar": true,
+		"LibertyMainColor": "#4188F1",
+		"LibertySecondColor": null,
+		"LibertyAdSetting": null,
+		"LibertyOgLogo": null,
+		"TwitterAccount": null,
+		"NaverVerification": null,
+		"wgLibertyMobileReplaceAd": false,
+		"LibertyLiveRCArticleNamespaces": [
+			0,
+			4,
+			10,
+			12,
+			14
+		],
+		"LibertyLiveRCTalkNamespaces": [
+			1,
+			3,
+			5,
+			7,
+			9,
+			11,
+			13,
+			15
+		],
+		"LibertyMaxRecent": 10
+	},
+	"AvailableRights": [
+		"blockads-header",
+		"blockads-right",
+		"blockads-belowarticle",
+		"blockads-bottom"
+	],
+	"ResourceModules": {
+		"skins.liberty.styles": {
+			"class": "ResourceLoaderSkinModule",
+			"features": {
+				"legacy": false,
+				"interface": false,
+				"toc": false
+			},
+			"styles": {
+				"bootstrap/css/bootstrap.min.css": {
+					"media": "all"
+				},
+				"css/default.css": {
+					"media": "all"
+				},
+				"css/default_mobile.css": {
+					"media": "all"
+				},
+				"css/wiki.css": {
+					"media": "all"
+				},
+				"css/only-mw.css": {
+					"media": "all"
+				},
+				"css/webfont.css": {
+					"media": "all"
+				},
+				"css/wiki-table.css": {
+					"media": "all"
+				},
+				"css/wikiedittor-liberty.css": {
+					"media": "all"
+				},
+				"css/extensions/RelatedArticles.css": {
+					"media": "all"
+				},
+				"css/print.css": {
+					"media": "print"
+				}
+			}
+		},
+		"skins.liberty.ads": {
+			"scripts": "js/ads.js"
+		},
+		"skins.liberty.bootstrap": {
+			"scripts": [
+				"js/lib/jquery.ba-throttle-debounce.js",
+				"js/lib/bootstrap.min.js"
+			]
+		},
+		"skins.liberty.layoutjs": {
+			"scripts": [
+				"js/delay-scrolling.js",
+				"js/disable-notice.js",
+				"js/share-button.js",
+				"js/layout.js",
+				"js/table.js",
+				"js/scroll-button.js"
+			],
+			"dependencies": "mediawiki.cookie"
+		},
+		"skins.liberty.liverc": {
+			"scripts": "js/live-recent.js",
+			"messages": [
+				"liberty-feed-new"
+			],
+			"dependencies": "mediawiki.util"
+		},
+		"skins.liberty.loginjs": {
+			"scripts": "js/login-request.js",
+			"dependencies": "mediawiki.util"
+		}
+	},
+	"ResourceFileModulePaths": {
+		"localBasePath": "",
+		"remoteSkinPath": "Liberty"
+	},
+	"ResourceModuleSkinStyles": {
+		"liberty": {
+			"+ext.relatedArticles.readMore": "css/extensions/RelatedArticles.css",
+			"+ext.echo.ui": "css/extensions/Echo.css",
+			"+mediawiki.action.view.filepage": "css/skinStyles/mediawiki.action.view.filepage.css",
+			"+mediawiki.special.preferences.styles": "css/skinStyles/mediawiki.special.preferences.styles.css"
+		}
+	},
+	"AutoloadClasses": {
+		"SkinLiberty": "SkinLiberty.php",
+		"LibertyTemplate": "LibertyTemplate.php",
+		"LibertyHooks": "LibertyHooks.php"
+	},
+	"Hooks": {
+		"GetPreferences": "LibertyHooks::onGetPreferences",
+		"OutputPageBodyAttributes": "LibertyHooks::onOutputPageBodyAttributes"
+	},
+	"manifest_version": 1
 }


### PR DESCRIPTION
Mostly just stylistic prettification to have the codebase conform to MediaWiki's code style since some of my earlier changes were undone in e.g. daa29db9927ee93411f2c73435219e3832a0dfc7 and earlier commits.

In `LibertyHooks.php` I fixed a typo and changed a variable name at the same time to a lowerCamelCase one as per MediaWiki's coding conventions. (The original variable name had a superfluous "e" in it.)

In some of the CSS files, I compacted longer multi-line statements like
```

.Liberty
    .content-wrapper
    .liberty-content
    .liberty-content-main
    .catlinks
    ul
    > li {
```
to a single-line statement like `.Liberty .content-wrapper .liberty-content .liberty-content-main .catlinks ul > li {`
because:
1. overall consistency with existing CSS (here and elsewhere)
2. overall consistency with MediaWiki's coding style
3. it just looked better to me

That said, it _may_ be desireable to convert some/most/all of these CSS files into LESS in the future, as it allows more "programmatical" writing of CSS rules without having to duplicate significant portions of a selector and it allows more sensible indentation of rules that's not possible in CSS. (Personally, though, I prefer CSS as-is, even if the cost of that is having somewhat long-ish lines or even having to break the lines at some point.)

In `share-button.js` I also added a few missing semi-colons.

P.S. Great to see Librewiki on GitHub! (I do wish GitHub wouldn't be such a pain about authentication, but...you win some, you lose some, I guess.)

cc @Revi for review