### PR TITLE
Restore MediaWiki 1.35(.3+) compatibility

### DIFF
--- a/LibertyTemplate.php
+++ b/LibertyTemplate.php
@@ -472,14 +472,23 @@ class LibertyTemplate extends BaseTemplate {
 	protected function contentsToolbox() {
 		$skin = $this->getSkin();
 		$user = $skin->getUser();
-		$watchlistManager = MediaWikiServices::getInstance()->getWatchlistManager();
 		$title = $skin->getTitle();
 		$revid = $skin->getRequest()->getText( 'oldid' );
-		$watched = $watchlistManager->isWatchedIgnoringRights( $user, $skin->getRelevantTitle() ) ? 'unwatch' : 'watch';
+		$services = MediaWikiServices::getInstance();
+
+		if ( method_exists( MediaWikiServices::class, 'getWatchlistManager' ) ) {
+			// MediaWiki 1.36+
+			$watchlistManager = $services->getWatchlistManager();
+			$watched = $watchlistManager->isWatchedIgnoringRights( $user, $skin->getRelevantTitle() ) ? 'unwatch' : 'watch';
+		} else {
+			// @phan-suppress-next-line PhanUndeclaredMethod
+			$watched = $user->isWatched( $skin->getRelevantTitle() ) ? 'unwatch' : 'watch';
+		}
+
 		$editable = isset( $this->data['content_navigation']['views']['edit'] );
 		$action = $skin->getRequest()->getVal( 'action', 'view' );
-		$permissionManager = MediaWikiServices::getInstance()->getPermissionManager();
-		$linkRenderer = MediaWikiServices::getInstance()->getLinkRenderer();
+		$permissionManager = $services->getPermissionManager();
+		$linkRenderer = $services->getLinkRenderer();
 		if ( $title->getNamespace() != NS_SPECIAL ) {
 			$companionTitle = $title->isTalkPage() ? $title->getSubjectPage() : $title->getTalkPage();
 		?>

--- a/skin.json
+++ b/skin.json
@@ -11,7 +11,7 @@
 	"type": "skin",
 	"version": "1.11.0",
 	"requires": {
-		"MediaWiki": ">= 1.37.0"
+		"MediaWiki": ">= 1.35.3"
 	},
 	"ValidSkinNames": {
 		"liberty": "Liberty"


### PR DESCRIPTION
This could be done rather easily with literally one simple `if()`, so why not?
After all, the 1.35 release is the current Long-Term Support (LTS) release so it makes sense to support it until the next LTS becomes available, given that Liberty is not using anything else that's strictly available only in MW 1.36+.