### PR TITLE
Low-effort MediaWiki 1.39 compatibility patch

### DIFF
--- a/LibertyTemplate.php
+++ b/LibertyTemplate.php
@@ -15,9 +15,7 @@ class LibertyTemplate extends BaseTemplate {
 		$request = $skin->getRequest();
 		$action = $request->getVal( 'action', 'view' );
 		$title = $skin->getTitle();
-		$LibertyUserSidebarSettings = $user->getOption( 'liberty-layout-sidebar' );
-
-		$this->html( 'headelement' );
+		$LibertyUserSidebarSettings = MediaWikiServices::getInstance()->getUserOptionsLookup()->getOption( $user, 'liberty-layout-sidebar' );
 ?>
 		<header>
 			<div class="nav-wrapper navbar-fixed-top">
@@ -80,9 +78,8 @@ class LibertyTemplate extends BaseTemplate {
 							$this->buildAd( 'belowarticle' );
 						}
 						?>
-						</div>
+					</div>
 					<footer>
-
 						<div class="liberty-footer">
 							<?php
 							if ( $this->data['dataAfterContent'] ) {
@@ -114,13 +111,11 @@ class LibertyTemplate extends BaseTemplate {
 			// @codingStandardsIgnoreLine
 			echo '<script async defer src="//pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>';
 		}
-		?>
-		<?php $this->loginModal(); ?>
-	<?php
-		$this->printTrail();
+
+		$this->loginModal();
+
 		$this->html( 'debughtml' );
-		echo Html::closeElement( 'body' );
-		echo Html::closeElement( 'html' );
+
 		echo "\n";
 	}
 

--- a/LibertyTemplate.php
+++ b/LibertyTemplate.php
@@ -15,7 +15,9 @@ class LibertyTemplate extends BaseTemplate {
 		$request = $skin->getRequest();
 		$action = $request->getVal( 'action', 'view' );
 		$title = $skin->getTitle();
+		// @codingStandardsIgnoreStart
 		$LibertyUserSidebarSettings = MediaWikiServices::getInstance()->getUserOptionsLookup()->getOption( $user, 'liberty-layout-sidebar' );
+		// @codingStandardsIgnoreEnd
 ?>
 		<header>
 			<div class="nav-wrapper navbar-fixed-top">

--- a/SkinLiberty.php
+++ b/SkinLiberty.php
@@ -1,6 +1,8 @@
 <?php
-// @codingStandardsIgnoreLine
-class SkinLiberty extends SkinTemplate{
+
+use MediaWiki\MediaWikiServices;
+
+class SkinLiberty extends SkinTemplate {
 	// @codingStandardsIgnoreStart
 	public $skinname = 'liberty';
 	public $stylename = 'Liberty';
@@ -17,14 +19,15 @@ class SkinLiberty extends SkinTemplate{
 		global $wgSitename, $wgTwitterAccount, $wgLanguageCode, $wgNaverVerification, $wgLogo, $wgLibertyEnableLiveRC, $wgLibertyAdSetting, $wgLibertyAdGroup, $wgLibertyNavBarLogoImage;
 
 		$user = $this->getUser();
+		$services = MediaWikiServices::getInstance();
+		$userOptionsLookup = $services->getUserOptionsLookup();
 		/* uncomment if needs to use UserGroupManager
-		$service = MediaWiki\MediaWikiServices::getInstance();
-		$usergroupmanager = $service->getUserGroupManager();
-		$userGroups = $usergroupmanager->getUserGroups($user);
+		$userGroupManager = $services->getUserGroupManager();
+		$userGroups = $userGroupManager->getUserGroups( $user );
 		*/
 
-		$optionMainColor = $user->getOption( 'liberty-color-main' );
-		$optionSecondColor = $user->getOption( 'liberty-color-second' );
+		$optionMainColor = $userOptionsLookup->getOption( $user, 'liberty-color-main' );
+		$optionSecondColor = $userOptionsLookup->getOption( $user, 'liberty-color-second' );
 
 		$mainColor = $optionMainColor ? $optionMainColor : $GLOBALS['wgLibertyMainColor'];
 		// @codingStandardsIgnoreLine
@@ -153,11 +156,10 @@ class SkinLiberty extends SkinTemplate{
 		}
 
 		// layout settings
-		$LibertyUserWidthSettings = $user->getOption( 'liberty-layout-width' );
-		$LibertyUserSidebarSettings = $user->getOption( 'liberty-layout-sidebar' );
-		$LibertyUserNavbarSettings = $user->getOption( 'liberty-layout-navfix' );
-		$LibertyUsercontrolbarSettings = $user->getOption( 'liberty-layout-controlbar' );
-
+		$LibertyUserWidthSettings = $userOptionsLookup->getOption( $user, 'liberty-layout-width' );
+		$LibertyUserSidebarSettings = $userOptionsLookup->getOption( $user, 'liberty-layout-sidebar' );
+		$LibertyUserNavbarSettings = $userOptionsLookup->getOption( $user, 'liberty-layout-navfix' );
+		$LibertyUsercontrolbarSettings = $userOptionsLookup->getOption( $user, 'liberty-layout-controlbar' );
 
 		if ( isset( $LibertyUserNavbarSettings ) && $LibertyUserNavbarSettings ) {
 			$out->addInlineStyle(
@@ -195,8 +197,8 @@ class SkinLiberty extends SkinTemplate{
 			);
 		}
 
-		// 폰트 설정
-		$LibertyUserFontSettings = $user->getOption( 'liberty-font' );
+		// Font settings
+		$LibertyUserFontSettings = $userOptionsLookup->getOption( $user, 'liberty-font' );
 		if ( $LibertyUserFontSettings !== null ) {
 			$out->addInlineStyle(
 				"body, h1, h2, h3, h4, h5, h6, b {
@@ -211,27 +213,27 @@ class SkinLiberty extends SkinTemplate{
 			if ( isset( $wgLibertyAdGroup ) && $wgLibertyAdGroup == 'differ' ) {
 				if (
 					isset( $wgLibertyAdSetting['header'] ) && $wgLibertyAdSetting['header'] &&
-					$user->getOption( 'liberty-ads-header' )
+					$userOptionsLookup->getOption( $user, 'liberty-ads-header' )
 				) {
-					$wgLibertyAdSetting['header'] == null;
+					$wgLibertyAdSetting['header'] = null;
 				}
 				if (
 					isset( $wgLibertyAdSetting['right'] ) && $wgLibertyAdSetting['right'] &&
-					$user->getOption( 'liberty-ads-right' )
+					$userOptionsLookup->getOption( $user, 'liberty-ads-right' )
 				) {
-					$wgLibertyAdSetting['right'] == null;
+					$wgLibertyAdSetting['right'] = null;
 				}
 				if (
 					isset( $wgLibertyAdSetting['bottom'] ) && $wgLibertyAdSetting['bottom'] &&
-					$user->getOption( 'liberty-ads-bottom' )
+					$userOptionsLookup->getOption( $user, 'liberty-ads-bottom' )
 				) {
-					$wgLibertyAdSetting['bottom'] == null;
+					$wgLibertyAdSetting['bottom'] = null;
 				}
 				if (
 					isset( $wgLibertyAdSetting['belowarticle'] ) && $wgLibertyAdSetting['belowarticle'] &&
-					$user->getOption( 'liberty-ads-belowarticle' )
+					$userOptionsLookup->getOption( $user, 'liberty-ads-belowarticle' )
 				) {
-					$wgLibertyAdSetting['belowarticle'] == null;
+					$wgLibertyAdSetting['belowarticle'] = null;
 				}
 			}
 		}
@@ -264,7 +266,7 @@ class SkinLiberty extends SkinTemplate{
 		.Liberty .content-wrapper .liberty-content .liberty-content-main .toccolours, .Liberty .content-wrapper .liberty-content .liberty-content-main .toc ul, .Liberty .content-wrapper .liberty-content .liberty-content-main .toc li { background-color: #000; }
 		.Liberty .content-wrapper .liberty-content .liberty-content-main .toc .toctitle { background-color: #1F2023; }";
 
-		$LibertyUserDarkSetting = $user->getOption( 'liberty-dark' );
+		$LibertyUserDarkSetting = $userOptionsLookup->getOption( $user, 'liberty-dark' );
 		if ( $LibertyUserDarkSetting === 'dark' ) {
 			$out->addInlineStyle( $LibertyDarkCss );
 		} elseif ( $LibertyUserDarkSetting === null ) {

--- a/skin.json
+++ b/skin.json
@@ -9,12 +9,25 @@
 	"namemsg": "skinname-liberty",
 	"license-name": "GPL-3.0-or-later",
 	"type": "skin",
-	"version": "1.12.0",
+	"version": "1.13.0",
 	"requires": {
-		"MediaWiki": ">= 1.37.0"
+		"MediaWiki": ">= 1.39.0"
 	},
 	"ValidSkinNames": {
-		"liberty": "Liberty"
+		"liberty": {
+			"displayname": "Liberty",
+			"class": "SkinLiberty",
+			"args": [ {
+				"name": "liberty",
+				"bodyClasses": [ "Liberty", "width-size" ],
+				"bodyOnly": true,
+				"responsive": true,
+				"template": "LibertyTemplate",
+				"styles": [
+					"skins.liberty.styles"
+				]
+			} ]
+		}
 	},
 	"MessagesDirs": {
 		"Liberty": [
@@ -30,7 +43,7 @@
 		"LibertyOgLogo": null,
 		"TwitterAccount": null,
 		"NaverVerification": null,
-		"wgLibertyMobileReplaceAd": false,
+		"LibertyMobileReplaceAd": false,
 		"LibertyLiveRCArticleNamespaces": [
 			0,
 			4,


### PR DESCRIPTION
* Using UserOptionsLookup service instead of removed User#getOption for getting preference values
* 'headelement', printTrail() and closing `</body>` and `</html>` tags removed to avoid emitting deprecation notices
* Bumped skin version number
* Bumped required MW version number from 1.37.0 to 1.39.0 just to make sure

Unrelated stuff I'm including just because:
* Removed CI suppression from SkinLiberty.php and added a missing space to the "class SkinLiberty extends SkinTemplate" line; I think that's all that's needed to make CI happy
* Translated (via Google Translate) one Korean comment to English
* Fixed incorrect variable name in skin.json ("wg" prefix is the default and does not need to be specified)
* Fixed incorrect variable assignments in SkinLiberty.php, or rather, what was supposed to be a variable assignment was confusingly a weird comparison?

Notes:
* LibertyHooks#onOutputPageBodyAttributes should now be obsolete and safe to remove, I believe
* Did I already mention that this is a low-effort patch? Because this is. I've tested it with a few pages but I've not extensively looked into the CSS etc.; maybe there's a solid reason to make further use of the "features" stuff for the "skins.liberty.styles" ResourceLoader module.
* Likewise, there might be a reason to load some JS also via that skin definition block in skin.json which contains the "styles" stuff, "scripts" is supported there BUT as far as I'm aware, it obviously cannot do conditionals like "load ad JS only when ads are enabled" or "load login JS only for anons" or "load live RC JS only when live RC is enabled"; thus IMO it makes most sense to load all the JS in initPage() as per usual.

References #16.