### PR TITLE
CI: update GitHub Actions workflow files

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,12 +1,14 @@
+---
 name: "Lint code"
 on: [pull_request, push]
 
 jobs:
   phpcs:
     name: Run phpcs
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout code
+        uses: actions/checkout@v4
 
       - uses: shivammathur/setup-php@v2
         with:
@@ -21,6 +23,6 @@ jobs:
     name: Run eslint
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - run: npm install --location=global eslint eslint-config-wikimedia eslint-plugin-json
     - run: eslint js --ignore-pattern 'lib/'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,3 +1,4 @@
+---
 name: "Automatically close stale issues/PRs"
 on:
   workflow_dispatch:
@@ -9,7 +10,7 @@ jobs:
   stale: 
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v4
+      - uses: actions/stale@v9
         with:
           stale-issue-message: 'This issue is stale because it has been open for 180 days with no activity. Remove stale label or comment on it or it will be closed in 2 weeks.'
           stale-pr-message: 'This pull request is stale because it has been open for 180 days with no activity. Remove stale label or comment on it or it will be closed in 2 weeks.'


### PR DESCRIPTION
1. Use latest `actions/checkout` version, suppressing old node version warning.
2. Run ubuntu-latest.
3. Fix some yaml syntax.
4. Use latest `actions/stale` version, suppressing old node version warning.