### PR TITLE
CSS fixes to reflect Heading HTML changes in MW 1.45+

### DIFF
--- a/SkinLiberty.php
+++ b/SkinLiberty.php
@@ -206,7 +206,7 @@ class SkinLiberty extends SkinTemplate {
 		$LibertyUserFontSettings = $userOptionsLookup->getOption( $user, 'liberty-font' );
 		if ( $LibertyUserFontSettings !== null ) {
 			$out->addInlineStyle(
-				"body, h1, h2, h3, h4, h5, h6, b {
+				"body, h1, h2, h3, h4, h5, h6, mw-heading, b {
 					font-family: $LibertyUserFontSettings;
 				}"
 			);

--- a/css/default.css
+++ b/css/default.css
@@ -26,7 +26,8 @@ h2,
 h3,
 h4,
 h5,
-h6 {
+h6,
+.mw-heading {
 	font-family: "Apple SD Gothic Neo", "Spoqa Han Sans", "SpoqaHanSans",
 		"Noto Sans KR", "Noto Sans", "Noto Sans CJK KR", "NanumBarunGothic",
 		"Nanum Gothic", "KoPub Dotum", "Malgun Gothic", "맑은 고딕", sans-serif;
@@ -39,7 +40,8 @@ h3,
 h4,
 h5,
 h6,
-b {
+b,
+.mw-heading {
 	font-family: "Apple SD Gothic Neo", "Spoqa Han Sans", "SpoqaHanSans",
 		"Noto Sans KR", "Noto Sans", "Noto Sans CJK KR", "NanumBarunGothic",
 		"Nanum Gothic", "KoPub Dotum", "Malgun Gothic", "맑은 고딕", sans-serif;
@@ -49,27 +51,27 @@ input[type="password"] {
 	font-family: sans-serif;
 }
 
-h1 {
+.mw-heading1, h1 {
 	font-size: 2rem;
 }
 
-h2 {
+.mw-heading2, h2 {
 	font-size: 1.8rem;
 }
 
-h3 {
+.mw-heading3, h3 {
 	font-size: 1.6rem;
 }
 
-h4 {
+.mw-heading4, h4 {
 	font-size: 1.5rem;
 }
 
-h5 {
+.mw-heading5, h5 {
 	font-size: 1.3rem;
 }
 
-h6 {
+.mw-heading6, h6 {
 	font-size: 1.1rem;
 }
 

--- a/css/only-mw.css
+++ b/css/only-mw.css
@@ -60,13 +60,29 @@
 .Liberty .content-wrapper .liberty-content .liberty-content-main h3,
 .Liberty .content-wrapper .liberty-content .liberty-content-main h4,
 .Liberty .content-wrapper .liberty-content .liberty-content-main h5,
-.Liberty .content-wrapper .liberty-content .liberty-content-main h6 {
+.Liberty .content-wrapper .liberty-content .liberty-content-main h6,
+.Liberty .content-wrapper .liberty-content .liberty-content-main .mw-heading {
 	margin-top: 1rem;
 	border-bottom: 1px dashed #e1e8ed;
 	margin-bottom: 0.6rem;
 	padding-bottom: 0.6rem;
 	overflow-wrap: break-word;
 	overflow: hidden;
+}
+
+.Liberty .content-wrapper .liberty-content .liberty-content-main .mw-heading h1,
+.Liberty .content-wrapper .liberty-content .liberty-content-main .mw-heading h2,
+.Liberty .content-wrapper .liberty-content .liberty-content-main .mw-heading h3,
+.Liberty .content-wrapper .liberty-content .liberty-content-main .mw-heading h4,
+.Liberty .content-wrapper .liberty-content .liberty-content-main .mw-heading h5,
+.Liberty .content-wrapper .liberty-content .liberty-content-main .mw-heading h6 {
+	display: inline;
+	margin-top: 0;
+	border-bottom: none;
+	margin-bottom: 0;
+	padding-bottom: 0;
+	overflow-wrap: inherit;
+	overflow: inherit;
 }
 
 .Liberty .content-wrapper .liberty-content .liberty-content-main .mw-headline-number {

--- a/css/print.css
+++ b/css/print.css
@@ -78,13 +78,24 @@ p {
 	border: 0 !important;
 }
 
-h1,
-h2 {
+.mw-heading1, h1,
+.mw-heading2, h2 {
 	border-bottom: 3px solid #000 !important;
 }
 
-h3,
-h4,
-h5 {
+.mw-heading h1,
+.mw-heading h2 {
+    border-bottom: none !important;
+}
+
+.mw-heading3, h3,
+.mw-heading4, h4,
+.mw-heading5, h5 {
 	border-color: #aaa !important;
+}
+
+.mw-heading h3,
+.mw-heading h4,
+.mw-heading h5 {
+	border-color: inherit !important;
 }


### PR DESCRIPTION
미디어위키 1.45에서 문단 제목이 이상하게 표시되는 것을 수정해보았습니다.

아래의 글을 참조해서 수정하였습니다.
https://www.mediawiki.org/wiki/Heading_HTML_changes